### PR TITLE
Only show download percentage when it has increased by a whole number

### DIFF
--- a/Project-Aurora/Aurora-Updater/UpdateManager.cs
+++ b/Project-Aurora/Aurora-Updater/UpdateManager.cs
@@ -69,7 +69,7 @@ namespace Aurora_Updater
         private float downloadProgess = 0.0f;
         private float extractProgess = 0.0f;
         public UpdateStatus updateState = UpdateStatus.None;
-        private int downloadProgressCheck = 0;
+        private int? previousPercentage;
         private int secondsLeft = 15;
         private Aurora.Settings.Configuration Config;
         private GitHubClient gClient = new GitHubClient(new ProductHeaderValue("aurora-updater"));
@@ -169,13 +169,14 @@ namespace Aurora_Updater
             double totalBytes = double.Parse(e.TotalBytesToReceive.ToString());
             double percentage = bytesIn / totalBytes;
 
-            downloadProgressCheck++;
+            int newPercentage = (int)(percentage * 100);
+            if (previousPercentage == newPercentage)
+                return;
 
-            if (downloadProgressCheck % 10 == 0)
-            {
-                log.Enqueue(new LogEntry("Download " + Math.Truncate(percentage * 100) + "%"));
-                this.downloadProgess = (float)(Math.Truncate(percentage * 100) / 100.0f);
-            }
+            previousPercentage = newPercentage;
+
+            log.Enqueue(new LogEntry("Download " + newPercentage + "%"));
+            downloadProgess = newPercentage / 100.0f;
         }
 
         void client_DownloadFileCompleted(object sender, AsyncCompletedEventArgs e)


### PR DESCRIPTION
<!-- Thank you for helping Aurora grow as a community project! We appreciate your help, and would love to see more additions to our code from you! :)  -->

<!-- 
============================
A checklist before submitting a Pull Request
============================
1. Ensure that your code follows the CamelCase naming convention. ( https://en.wikipedia.org/wiki/Camel_case )
2. Ensure that you are making a pull request for the dev branch, and not master branch. ( Master branch commits will not be accepted )
3. Fill out the form below with as much information as you can. Feel free to add more comments if you need to.
 -->

**This pull request proposes the following changes:**
In the updater, this fixes the percentage spamming when downloading the update.
Only show a new percentage when it has increased by a whole number to prevent spamming the log
