### PR TITLE
Update Elite Dangerous Profile to 4.0 for Horizons/Odyssey Keybind Lighting

### DIFF
--- a/Project-Aurora/Project-Aurora/Profiles/EliteDangerous/EliteConfig.cs
+++ b/Project-Aurora/Project-Aurora/Profiles/EliteDangerous/EliteConfig.cs
@@ -21,6 +21,6 @@ namespace Aurora.Profiles.EliteDangerous
             "Options",
             "Bindings"
         );
-        public static readonly string BINDINGS_PRESET_FILE = Path.Combine(BINDINGS_DIR, "StartPreset.start");
+        public static readonly string BINDINGS_PRESET_FILE = Path.Combine(BINDINGS_DIR, "StartPreset.4.start");
     }
 }

--- a/Project-Aurora/Project-Aurora/Profiles/EliteDangerous/GameEvent_EliteDangerous.cs
+++ b/Project-Aurora/Project-Aurora/Profiles/EliteDangerous/GameEvent_EliteDangerous.cs
@@ -9,6 +9,7 @@ using Aurora.Profiles.EliteDangerous.GSI;
 using Aurora.Profiles.EliteDangerous.GSI.Nodes;
 using Aurora.Profiles.EliteDangerous.Helpers;
 using Aurora.Profiles.EliteDangerous.Journal;
+using CSScripting;
 using Newtonsoft.Json;
 
 namespace Aurora.Profiles.EliteDangerous
@@ -201,8 +202,8 @@ namespace Aurora.Profiles.EliteDangerous
         {
             if (File.Exists(EliteConfig.BINDINGS_PRESET_FILE))
             {
-                string currentBindPrefix = File.ReadAllText(EliteConfig.BINDINGS_PRESET_FILE).Trim();
-                currentBindFile = SearchForBindsFile(EliteConfig.BINDINGS_DIR, currentBindPrefix);
+                string[] currentBindPrefix = File.ReadAllText(EliteConfig.BINDINGS_PRESET_FILE).GetLines();
+                currentBindFile = SearchForBindsFile(EliteConfig.BINDINGS_DIR, currentBindPrefix[1].Trim());
 
                 if (currentBindFile == null)
                 {
@@ -229,7 +230,7 @@ namespace Aurora.Profiles.EliteDangerous
                     if (defaultBindsDirectory != null)
                     {
                         ((EliteDangerousSettings) Application.Settings).GamePath = currentGamePath;
-                        currentBindFile = SearchForBindsFile(defaultBindsDirectory, currentBindPrefix);
+                        currentBindFile = SearchForBindsFile(defaultBindsDirectory, currentBindPrefix[1]);
                         if (currentBindFile != null)
                         {
                             Global.logger.Info("Found default binds file: " + currentBindFile);
@@ -266,7 +267,7 @@ namespace Aurora.Profiles.EliteDangerous
         private string SearchForBindsFile(string directory, string filePrefix)
         {
             string returnBindsFile = null;
-            foreach (string bindFile in Directory.GetFiles(directory, filePrefix + ".*.binds")
+            foreach (string bindFile in Directory.GetFiles(directory, filePrefix + "*.binds")
             )
             {
                 returnBindsFile = bindFile;


### PR DESCRIPTION
<!-- Thank you for helping Aurora grow as a community project! We appreciate your help, and would love to see more additions to our code from you! :)  -->

<!-- 
============================
A checklist before submitting a Pull Request
============================
1. Ensure that your code follows the CamelCase naming convention. ( https://en.wikipedia.org/wiki/Camel_case )
2. Ensure that you are making a pull request for the dev branch, and not master branch. ( Master branch commits will not be accepted )
3. Fill out the form below with as much information as you can. Feel free to add more comments if you need to.
 -->

**List any issues that this PR fixes:** fixes # , etc...
<!-- For example, "Fixes #287 , fixes #100 , and fixes #20" -->
- Fixes #94 

**This pull request proposes the following changes:**
<!-- List changes that this RP includes -->
- Fixes the Reading of the Elite Dangerous 4.0 Bindings. This makes the Keybind Lighting work again but breaks support for Legacy, which isn't supported by FDev any more anyway.

The new "StartPreset.4.start" contains 4 Lines now which correspond to the Configs set for each of the 4 Bindings Categorys ingame.

Basic
Flight
SRV
On-Foot

This Code reads the second Line. Flight.