### PR TITLE
Fix for sleep / wake device behavior

### DIFF
--- a/Project-Aurora/Project-Aurora/ConfigUI.xaml.cs
+++ b/Project-Aurora/Project-Aurora/ConfigUI.xaml.cs
@@ -107,7 +107,7 @@ partial class ConfigUI : INotifyPropertyChanged
 
     internal void DisplayIfNotSilent()
     {
-        if (App.IsSilent)
+        if (App.IsSilent || Global.Configuration.StartSilently)
         {
             Visibility = Visibility.Hidden;
             WindowStyle = WindowStyle.None;

--- a/Project-Aurora/Project-Aurora/ConfigUI.xaml.cs
+++ b/Project-Aurora/Project-Aurora/ConfigUI.xaml.cs
@@ -107,7 +107,7 @@ partial class ConfigUI : INotifyPropertyChanged
 
     internal void DisplayIfNotSilent()
     {
-        if (App.IsSilent || Global.Configuration.StartSilently)
+        if (App.IsSilent)
         {
             Visibility = Visibility.Hidden;
             WindowStyle = WindowStyle.None;

--- a/Project-Aurora/Project-Aurora/Devices/DeviceManager.cs
+++ b/Project-Aurora/Project-Aurora/Devices/DeviceManager.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using Amib.Threading;
 using CSScriptLib;
+using System.Windows.Threading;
 
 namespace Aurora.Devices
 {
@@ -366,7 +367,7 @@ namespace Aurora.Devices
                 Global.logger.Info("Resuming Devices -- Session Switch Session Unlock");
                 suspended = false;
                 resumed = false;
-                Task.Run(async () => await InitializeDevices());
+                Dispatcher.CurrentDispatcher.Invoke(async () => await InitializeDevices());
             }
         }
 
@@ -377,14 +378,14 @@ namespace Aurora.Devices
                 case PowerModes.Suspend:
                     Global.logger.Info("Suspending Devices");
                     suspended = true;
-                    Task.Run(async () => await this.ShutdownDevices());
+                    Dispatcher.CurrentDispatcher.Invoke(async () => await this.ShutdownDevices());
                     break;
                 case PowerModes.Resume:
                     Global.logger.Info("Resuming Devices -- PowerModes.Resume");
                     Thread.Sleep(TimeSpan.FromSeconds(2));
                     resumed = true;
                     suspended = false;
-                    Task.Run(async () => await this.InitializeDevices());
+                    Dispatcher.CurrentDispatcher.Invoke(async () => await this.InitializeDevices());
                     break;
             }
         }


### PR DESCRIPTION
## Summary
During sleep, device shutdown was started, but not run synchronously, and so wake would fail. This change basically makes both operations synchronous.

## Changes
- Mitigate thread context deadlock on sleep / wake
- Check app configuration in addition to command args to start minimized
