### PR TITLE
Per-device color calibration with assisted 3D-LUT wizard

### DIFF
--- a/Project-Aurora/AuroraCommon/Devices/CalibrationMath.cs
+++ b/Project-Aurora/AuroraCommon/Devices/CalibrationMath.cs
@@ -1,0 +1,105 @@
+using System.Collections.Generic;
+
+namespace Common.Devices;
+
+/// <summary>
+/// Fits a <see cref="ColorMatrix"/> from a set of (reference color -> matched target output) samples
+/// using least squares, so a device's mixed colors visually match a reference device.
+/// </summary>
+public static class CalibrationMath
+{
+    /// <summary>
+    /// Solves for the 3x3 matrix M (normalized RGB) minimizing the squared error of M * input ≈ output
+    /// over all samples. A small ridge term keeps the system well-conditioned.
+    /// </summary>
+    public static ColorMatrix FitColorMatrix(IReadOnlyList<SimpleColor> inputs, IReadOnlyList<SimpleColor> outputs)
+    {
+        var n = System.Math.Min(inputs.Count, outputs.Count);
+        if (n < 3)
+        {
+            return ColorMatrix.Identity;
+        }
+
+        // Normal equations: A = sum(c c^T); for each output channel k, rhs_k = sum(c * o_k).
+        var a = new double[9];
+        var rhs = new double[9]; // rhs[k*3 + j]
+
+        for (var i = 0; i < n; i++)
+        {
+            double[] c = [inputs[i].R / 255.0, inputs[i].G / 255.0, inputs[i].B / 255.0];
+            double[] o = [outputs[i].R / 255.0, outputs[i].G / 255.0, outputs[i].B / 255.0];
+
+            for (var r = 0; r < 3; r++)
+            {
+                for (var col = 0; col < 3; col++)
+                {
+                    a[r * 3 + col] += c[r] * c[col];
+                }
+            }
+
+            for (var k = 0; k < 3; k++)
+            {
+                for (var j = 0; j < 3; j++)
+                {
+                    rhs[k * 3 + j] += c[j] * o[k];
+                }
+            }
+        }
+
+        const double ridge = 1e-3;
+        a[0] += ridge;
+        a[4] += ridge;
+        a[8] += ridge;
+
+        if (!TryInvert3X3(a, out var inv))
+        {
+            return ColorMatrix.Identity;
+        }
+
+        var m = new double[9];
+        for (var k = 0; k < 3; k++)
+        {
+            for (var j = 0; j < 3; j++)
+            {
+                var sum = 0.0;
+                for (var l = 0; l < 3; l++)
+                {
+                    sum += inv[j * 3 + l] * rhs[k * 3 + l];
+                }
+
+                m[k * 3 + j] = sum;
+            }
+        }
+
+        return new ColorMatrix(m);
+    }
+
+    private static bool TryInvert3X3(double[] a, out double[] inv)
+    {
+        var det =
+            a[0] * (a[4] * a[8] - a[5] * a[7]) -
+            a[1] * (a[3] * a[8] - a[5] * a[6]) +
+            a[2] * (a[3] * a[7] - a[4] * a[6]);
+
+        if (System.Math.Abs(det) < 1e-9)
+        {
+            inv = [];
+            return false;
+        }
+
+        var d = 1.0 / det;
+        inv =
+        [
+            (a[4] * a[8] - a[5] * a[7]) * d,
+            (a[2] * a[7] - a[1] * a[8]) * d,
+            (a[1] * a[5] - a[2] * a[4]) * d,
+            (a[5] * a[6] - a[3] * a[8]) * d,
+            (a[0] * a[8] - a[2] * a[6]) * d,
+            (a[2] * a[3] - a[0] * a[5]) * d,
+            (a[3] * a[7] - a[4] * a[6]) * d,
+            (a[1] * a[6] - a[0] * a[7]) * d,
+            (a[0] * a[4] - a[1] * a[3]) * d
+        ];
+        return true;
+    }
+}

--- a/Project-Aurora/AuroraCommon/Devices/DeviceCalibration.cs
+++ b/Project-Aurora/AuroraCommon/Devices/DeviceCalibration.cs
@@ -1,0 +1,366 @@
+using System.Collections.Concurrent;
+using System.Text.Json.Serialization;
+
+namespace Common.Devices;
+
+/// <summary>
+/// Per-device color calibration used to make devices from different models look the same.
+/// <para>The runtime pipeline per channel is: per-channel brightness <see cref="CalibrationCurve"/>
+/// (matches the brightness response), then a 3x3 <see cref="ColorMatrix"/> (matches the tonality of
+/// mixed colors via cross-channel terms), then the manual multiplicative fine-tune
+/// (Brightness / per-channel gain / Gamma).</para>
+/// <see cref="DeviceCalibration.Identity"/> leaves colors untouched.
+/// </summary>
+[method: JsonConstructor]
+public sealed record DeviceCalibration(
+    double Brightness = 1.0,
+    double RedGain = 1.0,
+    double GreenGain = 1.0,
+    double BlueGain = 1.0,
+    double Gamma = 1.0,
+    CalibrationCurve? RedCurve = null,
+    CalibrationCurve? GreenCurve = null,
+    CalibrationCurve? BlueCurve = null,
+    ColorMatrix? Matrix = null,
+    ColorSample[]? Samples = null)
+{
+    public static readonly DeviceCalibration Identity = new();
+
+    // Cached lookup tables are kept outside the record so they don't participate in value equality.
+    private static readonly ConcurrentDictionary<DeviceCalibration, CalibrationLookup> LookupCache = new();
+
+    [JsonIgnore]
+    public bool IsIdentity =>
+        Brightness is 1.0 && RedGain is 1.0 && GreenGain is 1.0 && BlueGain is 1.0 && Gamma is 1.0 &&
+        (RedCurve?.IsIdentity ?? true) && (GreenCurve?.IsIdentity ?? true) && (BlueCurve?.IsIdentity ?? true) &&
+        (Matrix?.IsIdentity ?? true) && (Samples is null || Samples.Length == 0);
+
+    /// <summary>
+    /// Returns the cached lookup for this calibration. Resolve once per device update (not per led)
+    /// and call <see cref="CalibrationLookup.Apply"/> to keep the update hot path allocation-free.
+    /// </summary>
+    public CalibrationLookup GetLookup()
+    {
+        // Dragging calibration sliders produces many transient values; keep the cache bounded.
+        if (LookupCache.Count > 256)
+        {
+            LookupCache.Clear();
+        }
+
+        return LookupCache.GetOrAdd(this, static c => new CalibrationLookup(c));
+    }
+
+    /// <summary>
+    /// Builds a calibration from the legacy multiplicative <see cref="SimpleColor"/> calibration,
+    /// where 255 meant "no change" and lower values darkened the channel.
+    /// </summary>
+    public static DeviceCalibration FromLegacy(SimpleColor color) => new(
+        RedGain: color.R / 255.0,
+        GreenGain: color.G / 255.0,
+        BlueGain: color.B / 255.0);
+}
+
+/// <summary>
+/// A per-channel response curve sampled at a set of input levels, used to match a device's brightness
+/// response to a reference device. Control points are (<see cref="Inputs"/>[i] -> <see cref="Outputs"/>[i]);
+/// intermediate values are linearly interpolated, with an implicit 0 -> 0 anchor and clamping past the
+/// last point.
+/// </summary>
+[method: JsonConstructor]
+public sealed record CalibrationCurve(byte[] Inputs, byte[] Outputs)
+{
+    [JsonIgnore]
+    public bool IsIdentity
+    {
+        get
+        {
+            if (Inputs.Length == 0 || Inputs.Length != Outputs.Length)
+            {
+                return true;
+            }
+
+            for (var i = 0; i < Inputs.Length; i++)
+            {
+                if (Inputs[i] != Outputs[i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+
+    /// <summary>Linearly interpolates the output for a given input level (0-255).</summary>
+    public double Map(int input)
+    {
+        if (Inputs.Length == 0 || Inputs.Length != Outputs.Length)
+        {
+            return input;
+        }
+
+        if (input <= Inputs[0])
+        {
+            return Inputs[0] == 0 ? Outputs[0] : Outputs[0] * (input / (double)Inputs[0]);
+        }
+
+        for (var i = 1; i < Inputs.Length; i++)
+        {
+            if (input > Inputs[i])
+            {
+                continue;
+            }
+
+            var span = Inputs[i] - Inputs[i - 1];
+            if (span == 0)
+            {
+                return Outputs[i];
+            }
+
+            var t = (input - Inputs[i - 1]) / (double)span;
+            return Outputs[i - 1] + t * (Outputs[i] - Outputs[i - 1]);
+        }
+
+        return Outputs[^1];
+    }
+}
+
+/// <summary>
+/// A 3x3 color-correction matrix operating on normalized RGB (each channel in [0,1]), row-major:
+/// out_r = m[0]*r + m[1]*g + m[2]*b, etc. Captures cross-channel tonality differences between devices
+/// (e.g. a target whose purple is off even when its primaries match).
+/// </summary>
+[method: JsonConstructor]
+public sealed record ColorMatrix(double[] Values)
+{
+    public static readonly ColorMatrix Identity = new([1, 0, 0, 0, 1, 0, 0, 0, 1]);
+
+    [JsonIgnore]
+    public bool IsIdentity
+    {
+        get
+        {
+            if (Values.Length != 9)
+            {
+                return true;
+            }
+
+            for (var i = 0; i < 9; i++)
+            {
+                var expected = i % 4 == 0 ? 1.0 : 0.0; // diagonal entries are indices 0,4,8
+                if (Math.Abs(Values[i] - expected) > 1e-6)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}
+
+/// <summary>
+/// A single calibration sample: the <see cref="Source"/> color sent and the <see cref="Output"/> the
+/// user matched on the target device. Used to bake a non-linear 3D correction (see
+/// <see cref="CalibrationLookup"/>) for mixed colors a single matrix can't fix.
+/// </summary>
+[method: JsonConstructor]
+public sealed record ColorSample(SimpleColor Source, SimpleColor Output);
+
+/// <summary>
+/// Precomputed apply pipeline for a <see cref="DeviceCalibration"/>: per-channel brightness curve LUTs,
+/// an optional 3x3 matrix and per-channel manual fine-tune LUTs. When <see cref="DeviceCalibration.Samples"/>
+/// are present, a non-linear 3D lookup table is baked from the curve+matrix base plus local sample
+/// corrections, and applied with trilinear interpolation.
+/// </summary>
+public sealed class CalibrationLookup
+{
+    private const int LutSize = 17; // grid nodes per axis of the baked 3D LUT
+
+    private readonly byte[] _curveR = new byte[256];
+    private readonly byte[] _curveG = new byte[256];
+    private readonly byte[] _curveB = new byte[256];
+
+    private readonly byte[] _manualR = new byte[256];
+    private readonly byte[] _manualG = new byte[256];
+    private readonly byte[] _manualB = new byte[256];
+
+    private readonly double[]? _matrix;
+
+    // baked 3D LUT (LutSize^3 nodes, interleaved RGB); null when no samples
+    private readonly byte[]? _lut;
+
+    internal CalibrationLookup(DeviceCalibration calibration)
+    {
+        BuildCurve(_curveR, calibration.RedCurve);
+        BuildCurve(_curveG, calibration.GreenCurve);
+        BuildCurve(_curveB, calibration.BlueCurve);
+
+        var invGamma = calibration.Gamma <= 0 ? 1.0 : 1.0 / calibration.Gamma;
+        BuildManual(_manualR, calibration.RedGain, calibration.Brightness, invGamma);
+        BuildManual(_manualG, calibration.GreenGain, calibration.Brightness, invGamma);
+        BuildManual(_manualB, calibration.BlueGain, calibration.Brightness, invGamma);
+
+        _matrix = calibration.Matrix is { IsIdentity: false } m && m.Values.Length == 9 ? m.Values : null;
+
+        if (calibration.Samples is { Length: > 0 } samples)
+        {
+            _lut = BakeLut(samples);
+        }
+    }
+
+    public SimpleColor Apply(in SimpleColor color)
+    {
+        int r, g, b;
+        if (_lut is { } lut)
+        {
+            (r, g, b) = TrilinearLookup(lut, color);
+        }
+        else
+        {
+            (r, g, b) = CurveMatrix(color);
+        }
+
+        return new SimpleColor(_manualR[r], _manualG[g], _manualB[b], color.A);
+    }
+
+    /// <summary>Applies the per-channel brightness curve then the 3x3 matrix (no manual stage).</summary>
+    private (int r, int g, int b) CurveMatrix(in SimpleColor color)
+    {
+        int r = _curveR[color.R];
+        int g = _curveG[color.G];
+        int b = _curveB[color.B];
+
+        if (_matrix is { } m)
+        {
+            var rn = r / 255.0;
+            var gn = g / 255.0;
+            var bn = b / 255.0;
+            r = ClampByte((m[0] * rn + m[1] * gn + m[2] * bn) * 255.0);
+            g = ClampByte((m[3] * rn + m[4] * gn + m[5] * bn) * 255.0);
+            b = ClampByte((m[6] * rn + m[7] * gn + m[8] * bn) * 255.0);
+        }
+
+        return (r, g, b);
+    }
+
+    private byte[] BakeLut(ColorSample[] samples)
+    {
+        // local-correction kernel over normalized RGB space
+        const double sigma = 0.22;
+        const double anchor = 0.05; // keeps regions far from any sample on the curve+matrix base
+        var twoSigmaSq = 2.0 * sigma * sigma;
+
+        var n = samples.Length;
+        var sr = new double[n];
+        var sg = new double[n];
+        var sb = new double[n];
+        var dr = new double[n];
+        var dg = new double[n];
+        var db = new double[n];
+        for (var i = 0; i < n; i++)
+        {
+            var src = samples[i].Source;
+            var dst = samples[i].Output;
+            var (br, bg, bb) = CurveMatrix(src);
+            sr[i] = src.R / 255.0;
+            sg[i] = src.G / 255.0;
+            sb[i] = src.B / 255.0;
+            // correction = desired output - base(source)
+            dr[i] = dst.R - br;
+            dg[i] = dst.G - bg;
+            db[i] = dst.B - bb;
+        }
+
+        var lut = new byte[LutSize * LutSize * LutSize * 3];
+        var idx = 0;
+        for (var ri = 0; ri < LutSize; ri++)
+        for (var gi = 0; gi < LutSize; gi++)
+        for (var bi = 0; bi < LutSize; bi++)
+        {
+            var node = new SimpleColor(GridLevel(ri), GridLevel(gi), GridLevel(bi));
+            var (baseR, baseG, baseB) = CurveMatrix(node);
+
+            var rn = ri / (double)(LutSize - 1);
+            var gn = gi / (double)(LutSize - 1);
+            var bn = bi / (double)(LutSize - 1);
+
+            double wSum = anchor, cr = 0, cg = 0, cb = 0;
+            for (var i = 0; i < n; i++)
+            {
+                var d2 = (rn - sr[i]) * (rn - sr[i]) + (gn - sg[i]) * (gn - sg[i]) + (bn - sb[i]) * (bn - sb[i]);
+                var w = Math.Exp(-d2 / twoSigmaSq);
+                wSum += w;
+                cr += w * dr[i];
+                cg += w * dg[i];
+                cb += w * db[i];
+            }
+
+            lut[idx++] = (byte)ClampDouble(baseR + cr / wSum);
+            lut[idx++] = (byte)ClampDouble(baseG + cg / wSum);
+            lut[idx++] = (byte)ClampDouble(baseB + cb / wSum);
+        }
+
+        return lut;
+    }
+
+    private static byte GridLevel(int i) => (byte)ClampDouble(i * 255.0 / (LutSize - 1));
+
+    private static (int r, int g, int b) TrilinearLookup(byte[] lut, in SimpleColor color)
+    {
+        var scale = LutSize - 1;
+        var fr = color.R / 255.0 * scale;
+        var fg = color.G / 255.0 * scale;
+        var fb = color.B / 255.0 * scale;
+
+        int r0 = (int)fr, g0 = (int)fg, b0 = (int)fb;
+        int r1 = Math.Min(r0 + 1, scale), g1 = Math.Min(g0 + 1, scale), b1 = Math.Min(b0 + 1, scale);
+        double tr = fr - r0, tg = fg - g0, tb = fb - b0;
+
+        double outR = 0, outG = 0, outB = 0;
+        for (var c = 0; c < 8; c++)
+        {
+            var ri = (c & 1) == 0 ? r0 : r1;
+            var gi = (c & 2) == 0 ? g0 : g1;
+            var bi = (c & 4) == 0 ? b0 : b1;
+            var wr = (c & 1) == 0 ? 1 - tr : tr;
+            var wg = (c & 2) == 0 ? 1 - tg : tg;
+            var wb = (c & 4) == 0 ? 1 - tb : tb;
+            var w = wr * wg * wb;
+
+            var o = ((ri * LutSize + gi) * LutSize + bi) * 3;
+            outR += w * lut[o];
+            outG += w * lut[o + 1];
+            outB += w * lut[o + 2];
+        }
+
+        return (ClampByte(outR), ClampByte(outG), ClampByte(outB));
+    }
+
+    private static void BuildCurve(byte[] table, CalibrationCurve? curve)
+    {
+        var hasCurve = curve is { IsIdentity: false };
+        for (var i = 0; i < 256; i++)
+        {
+            table[i] = hasCurve ? (byte)ClampByte(curve!.Map(i)) : (byte)i;
+        }
+    }
+
+    private static void BuildManual(byte[] table, double gain, double brightness, double invGamma)
+    {
+        for (var i = 0; i < 256; i++)
+        {
+            var normalized = Math.Pow(i / 255.0, invGamma) * brightness * gain;
+            table[i] = (byte)ClampDouble(normalized * 255.0);
+        }
+    }
+
+    private static int ClampByte(double value) => (int)ClampDouble(value);
+
+    private static double ClampDouble(double value) => value switch
+    {
+        >= 255.0 => 255.0,
+        <= 0.0 => 0.0,
+        _ => Math.Round(value)
+    };
+}

--- a/Project-Aurora/AuroraCommon/Devices/DeviceCommands.cs
+++ b/Project-Aurora/AuroraCommon/Devices/DeviceCommands.cs
@@ -12,6 +12,8 @@ public static class DeviceCommands
     public const string Unmap = "unmap";
     public const string Share = "share";
     public const string Recalibrate = "recalibrate";
+    public const string CalibrationPreview = "calibrationPreview";
+    public const string CalibrationEnd = "calibrationEnd";
 
     // Aurora Interface
     public const string RemappableDevices = "remappableDevices";

--- a/Project-Aurora/AuroraCommon/Devices/DeviceConfig.cs
+++ b/Project-Aurora/AuroraCommon/Devices/DeviceConfig.cs
@@ -16,7 +16,15 @@ public sealed partial class DeviceConfig : INotifyPropertyChanged, IAuroraConfig
 
     public event PropertyChangedEventHandler? PropertyChanged;
 
+    /// <summary>
+    /// Legacy multiplicative calibration kept only for migration into <see cref="DeviceColorCalibrations"/>.
+    /// </summary>
     public Dictionary<string, SimpleColor> DeviceCalibrations { get; set; } = new();
+
+    /// <summary>
+    /// Per-device color calibration keyed by device name.
+    /// </summary>
+    public Dictionary<string, DeviceCalibration> DeviceColorCalibrations { get; set; } = new();
 
     [JsonPropertyName("allow_peripheral_devices")]
     public bool AllowPeripheralDevices { get; set; } = true;
@@ -95,12 +103,23 @@ public sealed partial class DeviceConfig : INotifyPropertyChanged, IAuroraConfig
     {
         _enabledControllers ??= new ObservableCollection<string>(DefaultEnabledControllers);
 
+        MigrateCalibrations();
         MigrateDevices();
 
         PrioritizeDevice("Logitech (RGB.NET)", "Logitech");
 
         EnabledControllers.CollectionChanged += (_, _) =>
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(EnabledControllers)));
+    }
+
+    private void MigrateCalibrations()
+    {
+        foreach (var (deviceName, color) in DeviceCalibrations)
+        {
+            DeviceColorCalibrations.TryAdd(deviceName, DeviceCalibration.FromLegacy(color));
+        }
+
+        DeviceCalibrations.Clear();
     }
 
     private void MigrateDevices()

--- a/Project-Aurora/AuroraCommon/Devices/RGBNet/RemappableDevice.cs
+++ b/Project-Aurora/AuroraCommon/Devices/RGBNet/RemappableDevice.cs
@@ -4,7 +4,7 @@ using RGB.NET.Core;
 namespace Common.Devices.RGBNet;
 
 [method: JsonConstructor]
-public class RemappableDevice(bool isEnabled, string deviceId, string deviceSummary, List<LedId> rgbNetLeds, SimpleColor calibration, bool remapEnabled)
+public class RemappableDevice(bool isEnabled, string deviceId, string deviceSummary, List<LedId> rgbNetLeds, DeviceCalibration calibration, bool remapEnabled)
 {
     public bool IsEnabled { get; } = isEnabled;
 
@@ -14,7 +14,7 @@ public class RemappableDevice(bool isEnabled, string deviceId, string deviceSumm
     // $"[{rgbDevice.DeviceInfo.DeviceType}] {rgbDevice.DeviceInfo.DeviceName}"
     public List<LedId> RgbNetLeds { get; } = rgbNetLeds;
 
-    public SimpleColor Calibration { get; } = calibration;
+    public DeviceCalibration Calibration { get; } = calibration;
 
     public bool RemapEnabled { get; } = remapEnabled;
 }

--- a/Project-Aurora/AuroraCommon/Utils/CommonSourceGenerationContext.cs
+++ b/Project-Aurora/AuroraCommon/Utils/CommonSourceGenerationContext.cs
@@ -7,4 +7,8 @@ namespace Common.Utils;
 [JsonSourceGenerationOptions(WriteIndented = true)]
 [JsonSerializable(typeof(DeviceMappingConfig))]
 [JsonSerializable(typeof(DeviceConfig))]
+[JsonSerializable(typeof(DeviceCalibration))]
+[JsonSerializable(typeof(CalibrationCurve))]
+[JsonSerializable(typeof(ColorMatrix))]
+[JsonSerializable(typeof(ColorSample))]
 public partial class CommonSourceGenerationContext : JsonSerializerContext;

--- a/Project-Aurora/AuroraDeviceManager/AuroraPipe.cs
+++ b/Project-Aurora/AuroraDeviceManager/AuroraPipe.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO.Pipes;
 using System.Security.AccessControl;
 using System.Security.Principal;
+using System.Text.Json;
 using AuroraDeviceManager.Devices;
 using AuroraDeviceManager.Utils;
 using Common;
@@ -117,9 +118,22 @@ public sealed class AuroraPipe : IDisposable
                 case DeviceCommands.Recalibrate:
                 {
                     var deviceId = splits.Next();
-                    var color = SimpleColor.FromArgb(int.Parse(splits.Next()));
+                    var calibration = JsonSerializer.Deserialize(splits.Next(), SourceGenerationContext.Default.DeviceCalibration)
+                                      ?? DeviceCalibration.Identity;
 
-                    Global.DeviceConfig.DeviceCalibrations[deviceId] = color;
+                    Global.DeviceConfig.DeviceColorCalibrations[deviceId] = calibration;
+                    break;
+                }
+                case DeviceCommands.CalibrationPreview:
+                {
+                    var deviceId = splits.Next();
+                    var color = SimpleColor.FromArgb(int.Parse(splits.Next()));
+                    _deviceManager.PreviewDeviceColor(deviceId, color);
+                    break;
+                }
+                case DeviceCommands.CalibrationEnd:
+                {
+                    _deviceManager.EndCalibration();
                     break;
                 }
                 default:

--- a/Project-Aurora/AuroraDeviceManager/Devices/DefaultDevice.cs
+++ b/Project-Aurora/AuroraDeviceManager/Devices/DefaultDevice.cs
@@ -90,7 +90,8 @@ public abstract class DefaultDevice : IDevice, IDisposable
             return Task.FromResult(false);
         }
         _updateWatch.Restart();
-        var updateResult = UpdateDevice(colorComposition.KeyColors, e, forced);
+        var keyColors = ApplyCalibration(colorComposition.KeyColors);
+        var updateResult = UpdateDevice(keyColors, e, forced);
 
         if (!updateResult.Result) return Task.FromResult(false);
         _lastUpdateTime = Watch.ElapsedMilliseconds;
@@ -103,6 +104,34 @@ public abstract class DefaultDevice : IDevice, IDisposable
     public virtual string? GetDevices()
     {
         return null;
+    }
+
+    /// <summary>
+    /// Whether the device applies color calibration itself (e.g. per sub-device). When false,
+    /// <see cref="DefaultDevice"/> applies the calibration registered for <see cref="DeviceName"/>.
+    /// </summary>
+    protected virtual bool AppliesOwnCalibration => false;
+
+    private Dictionary<DeviceKeys, SimpleColor>? _calibratedColors;
+
+    private Dictionary<DeviceKeys, SimpleColor> ApplyCalibration(Dictionary<DeviceKeys, SimpleColor> keyColors)
+    {
+        if (AppliesOwnCalibration ||
+            !Global.DeviceConfig.DeviceColorCalibrations.TryGetValue(DeviceName, out var calibration) ||
+            calibration.IsIdentity)
+        {
+            return keyColors;
+        }
+
+        var lookup = calibration.GetLookup();
+        var calibrated = _calibratedColors ??= new Dictionary<DeviceKeys, SimpleColor>(keyColors.Count);
+        calibrated.Clear();
+        foreach (var (key, color) in keyColors)
+        {
+            calibrated[key] = lookup.Apply(color);
+        }
+
+        return calibrated;
     }
 
     protected abstract Task<bool> DoInitialize(CancellationToken cancellationToken);

--- a/Project-Aurora/AuroraDeviceManager/Devices/DeviceManager.cs
+++ b/Project-Aurora/AuroraDeviceManager/Devices/DeviceManager.cs
@@ -158,6 +158,38 @@ public sealed class DeviceManager : IDisposable
     private CancellationTokenSource? _tokenSource;
     private const int BlinkCount = 7;
 
+    /// <summary>
+    /// Drives an RGB.NET device to a solid raw color (bypassing normal rendering and calibration)
+    /// so the assisted calibration wizard can show a test color. Held until the next preview or
+    /// <see cref="EndCalibration"/>.
+    /// </summary>
+    public void PreviewDeviceColor(string deviceId, SimpleColor color)
+    {
+        foreach (var auroraDevice in InitializedDeviceContainers.Select(container => container.Device).OfType<RgbNetDevice>())
+        {
+            foreach (var rgbNetDevice in auroraDevice.DeviceList.Where(rgbDevice => rgbDevice.DeviceInfo.DeviceName == deviceId))
+            {
+                auroraDevice.Disabled = true;
+                var rgbColor = new RgbNetColor(color.A, color.R, color.G, color.B);
+                foreach (var led in rgbNetDevice)
+                {
+                    led.Color = rgbColor;
+                }
+
+                rgbNetDevice.Update(true);
+            }
+        }
+    }
+
+    /// <summary>Re-enables normal rendering on all devices after an assisted calibration session.</summary>
+    public void EndCalibration()
+    {
+        foreach (var auroraDevice in InitializedDeviceContainers.Select(container => container.Device).OfType<RgbNetDevice>())
+        {
+            auroraDevice.Disabled = false;
+        }
+    }
+
     public void BlinkDevice(string deviceId, LedId led)
     {
         foreach (var auroraDevice in InitializedDeviceContainers.Select(container => container.Device).OfType<RgbNetDevice>())
@@ -221,18 +253,29 @@ public sealed class DeviceManager : IDisposable
     public async Task ShareRemappableDevices()
     {
         Global.Logger.Information("Updating CurrentDevices.json");
-        var rgbNetControllers = InitializedDeviceContainers.Select(dc => dc.Device).OfType<RgbNetDevice>();
+        var initializedDevices = InitializedDeviceContainers.Select(dc => dc.Device).ToList();
+        var rgbNetControllers = initializedDevices.OfType<RgbNetDevice>();
 
         var remappableDevices = (
             from rgbNetController in rgbNetControllers
             from device in rgbNetController.DeviceList
             let deviceId = device.DeviceInfo.DeviceName
             let isEnabled = !Global.DeviceConfig.DisabledControllerDevices.Contains(deviceId)
-            let calibration = Global.DeviceConfig.DeviceCalibrations.GetValueOrDefault(deviceId, SimpleColor.White)
+            let calibration = Global.DeviceConfig.DeviceColorCalibrations.GetValueOrDefault(deviceId, DeviceCalibration.Identity)
             let deviceSummary = $"{rgbNetController.DeviceName}: [{device.DeviceInfo.DeviceType}] {deviceId}"
             let rgbNetLeds = device.Select(l => l.Id).ToList()
             select new RemappableDevice(isEnabled, deviceId, deviceSummary, rgbNetLeds, calibration, !rgbNetController.NeedsLayout())
         ).ToList();
+
+        // Non-RGB.NET devices have no remappable leds but can still be calibrated.
+        var calibratableDevices =
+            from device in initializedDevices
+            where device is not RgbNetDevice
+            let deviceId = device.DeviceName
+            let calibration = Global.DeviceConfig.DeviceColorCalibrations.GetValueOrDefault(deviceId, DeviceCalibration.Identity)
+            select new RemappableDevice(true, deviceId, deviceId, [], calibration, false);
+
+        remappableDevices.AddRange(calibratableDevices);
 
         var currentDevices = new CurrentDevices(remappableDevices);
 

--- a/Project-Aurora/AuroraDeviceManager/Devices/RGBNet/RgbNetDevice.cs
+++ b/Project-Aurora/AuroraDeviceManager/Devices/RGBNet/RgbNetDevice.cs
@@ -58,6 +58,9 @@ public abstract class RgbNetDevice : DefaultDevice
         return _devicesString;
     }
 
+    // RGB.NET controllers calibrate each sub-device individually in RgbNetDeviceUpdater.
+    protected override bool AppliesOwnCalibration => true;
+
     protected override async Task<bool> DoInitialize(CancellationToken cancellationToken)
     {
         Global.Logger.Information("Initializing {DeviceName}", DeviceName);

--- a/Project-Aurora/AuroraDeviceManager/Devices/RGBNet/RgbNetDeviceUpdater.cs
+++ b/Project-Aurora/AuroraDeviceManager/Devices/RGBNet/RgbNetDeviceUpdater.cs
@@ -33,8 +33,7 @@ public class RgbNetDeviceUpdater(ConcurrentDictionary<IRGBDevice, Dictionary<Led
 
     private static void UpdateReverse(Dictionary<DeviceKeys, SimpleColor> keyColors, IRGBDevice device)
     {
-        var calibrationName = CalibrationName(device);
-        var calibrated = Global.DeviceConfig.DeviceCalibrations.TryGetValue(calibrationName, out var calibration);
+        var lookup = GetLookup(device);
         foreach (var key in keyColors.Keys)
         {
             ref var color = ref CollectionsMarshal.GetValueRefOrNullRef(keyColors, key);
@@ -56,9 +55,9 @@ public class RgbNetDeviceUpdater(ConcurrentDictionary<IRGBDevice, Dictionary<Led
             if (led == null)
                 continue;
 
-            if (calibrated)
+            if (lookup != null)
             {
-                UpdateLedCalibrated(led, in color, calibration);
+                UpdateLedCalibrated(led, in color, lookup);
             }
             else
             {
@@ -81,9 +80,8 @@ public class RgbNetDeviceUpdater(ConcurrentDictionary<IRGBDevice, Dictionary<Led
 
     private void UpdateStraight(Dictionary<DeviceKeys, SimpleColor> keyColors, IRGBDevice device)
     {
-        var calibrationName = CalibrationName(device);
         deviceKeyRemap.TryGetValue(device, out var keyRemap);
-        var calibrated = Global.DeviceConfig.DeviceCalibrations.TryGetValue(calibrationName, out var calibration);
+        var lookup = GetLookup(device);
         foreach (var led in device)
         {
             if (!(keyRemap != null &&
@@ -91,9 +89,9 @@ public class RgbNetDeviceUpdater(ConcurrentDictionary<IRGBDevice, Dictionary<Led
                 !RgbNetKeyMappings.KeyNames.TryGetValue(led.Id, out dk)) continue;
             if (!keyColors.TryGetValue(dk, out var color)) continue;
 
-            if (calibrated)
+            if (lookup != null)
             {
-                UpdateLedCalibrated(led, in color, calibration);
+                UpdateLedCalibrated(led, in color, lookup);
             }
             else
             {
@@ -112,19 +110,22 @@ public class RgbNetDeviceUpdater(ConcurrentDictionary<IRGBDevice, Dictionary<Led
         );
     }
 
-    private static void UpdateLedCalibrated(Led led, in SimpleColor color, SimpleColor calibration)
+    private static void UpdateLedCalibrated(Led led, in SimpleColor color, CalibrationLookup lookup)
     {
-        led.Color = new Color(
-            (byte)(color.A * calibration.A / 255),
-            (byte)(color.R * calibration.R / 255),
-            (byte)(color.G * calibration.G / 255),
-            (byte)(color.B * calibration.B / 255)
-        );
+        var c = lookup.Apply(color);
+        led.Color = new Color(c.A, c.R, c.G, c.B);
     }
 
-    private static string CalibrationName(IRGBDevice device)
+    private static CalibrationLookup? GetLookup(IRGBDevice device)
     {
-        return device.DeviceInfo.DeviceName;
+        var calibrationName = device.DeviceInfo.DeviceName;
+        if (!Global.DeviceConfig.DeviceColorCalibrations.TryGetValue(calibrationName, out var calibration) ||
+            calibration.IsIdentity)
+        {
+            return null;
+        }
+
+        return calibration.GetLookup();
     }
 
 }

--- a/Project-Aurora/AuroraDeviceManager/Utils/SourceGenerationContext.cs
+++ b/Project-Aurora/AuroraDeviceManager/Utils/SourceGenerationContext.cs
@@ -8,5 +8,9 @@ namespace AuroraDeviceManager.Utils;
 [JsonSerializable(typeof(DeviceConfig))]
 [JsonSerializable(typeof(CurrentDevices))]
 [JsonSerializable(typeof(DeviceMappingConfig))]
+[JsonSerializable(typeof(DeviceCalibration))]
+[JsonSerializable(typeof(CalibrationCurve))]
+[JsonSerializable(typeof(ColorMatrix))]
+[JsonSerializable(typeof(ColorSample))]
 [JsonSerializable(typeof(VariableRegistryItem))]
 public partial class SourceGenerationContext : JsonSerializerContext;

--- a/Project-Aurora/Project-Aurora/Controls/Control_CalibrationWizard.xaml
+++ b/Project-Aurora/Project-Aurora/Controls/Control_CalibrationWizard.xaml
@@ -1,0 +1,105 @@
+<Window x:Class="AuroraRgb.Controls.Control_CalibrationWizard"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        mc:Ignorable="d"
+        Closing="Window_OnClosing"
+        Title="Assisted Calibration" Height="470" Width="560">
+
+    <Grid Margin="14">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <!-- Setup -->
+        <StackPanel Grid.Row="0" Name="SetupPanel">
+            <TextBlock TextWrapping="Wrap" Margin="0,0,0,10"
+                       Text="Pick a reference device (the look you want) and a target device to match to it. Targets can only be dimmed, so choose your weakest/dimmest device as the reference." />
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="90" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+                <TextBlock Grid.Row="0" Grid.Column="0" Text="Reference" VerticalAlignment="Center" Margin="0,4" />
+                <ComboBox Grid.Row="0" Grid.Column="1" Name="ReferenceCombo" Margin="0,4" />
+                <TextBlock Grid.Row="1" Grid.Column="0" Text="Target" VerticalAlignment="Center" Margin="0,4" />
+                <ComboBox Grid.Row="1" Grid.Column="1" Name="TargetCombo" Margin="0,4" />
+            </Grid>
+            <TextBlock Margin="0,10,0,0" TextWrapping="Wrap" Opacity="0.8"
+                       Text="The wizard has two stages: (1) match the brightness of each channel, then (2) match the tonality of mixed colors (white + primaries + secondaries). A 3x3 color matrix is fitted from stage 2 so mixed colors match too." />
+            <TextBlock Name="SetupError" Foreground="#FFE57373" Margin="0,6,0,0" Visibility="Collapsed" />
+        </StackPanel>
+
+        <!-- Stage 1: per-channel brightness -->
+        <StackPanel Grid.Row="1" Name="Phase1Panel" Visibility="Collapsed" VerticalAlignment="Center">
+            <TextBlock Name="Phase1Step" FontWeight="Bold" FontSize="14" TextWrapping="Wrap" Margin="0,0,0,4" />
+            <TextBlock TextWrapping="Wrap" Margin="0,0,0,16"
+                       Text="Stage 1 — brightness. Drag until the TARGET's brightness for this channel matches the REFERENCE, then press Next." />
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="55" />
+                </Grid.ColumnDefinitions>
+                <TextBlock Grid.Column="0" Text="Target output" VerticalAlignment="Center" Margin="0,0,8,0" />
+                <Slider Grid.Column="1" Name="OutputSlider" Minimum="0" Maximum="255" VerticalAlignment="Center"
+                        ValueChanged="OutputSlider_OnValueChanged" />
+                <TextBlock Grid.Column="2" HorizontalAlignment="Right" VerticalAlignment="Center"
+                           Text="{Binding ElementName=OutputSlider, Path=Value, StringFormat={}{0:F0}}" />
+            </Grid>
+        </StackPanel>
+
+        <!-- Stage 2: mixed-color tonality -->
+        <StackPanel Grid.Row="1" Name="Phase2Panel" Visibility="Collapsed" VerticalAlignment="Center">
+            <TextBlock Name="Phase2Step" FontWeight="Bold" FontSize="14" TextWrapping="Wrap" Margin="0,0,0,4" />
+            <TextBlock TextWrapping="Wrap" Margin="0,0,0,16"
+                       Text="Stage 2 — tonality. Tweak the TARGET's red/green/blue until the color's TONE matches the REFERENCE (not just brightness), then press Next." />
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="60" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="45" />
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+                <TextBlock Grid.Row="0" Grid.Column="0" Text="Red" Foreground="#FFE57373" VerticalAlignment="Center" />
+                <Slider Grid.Row="0" Grid.Column="1" Name="RedSlider" Minimum="0" Maximum="255" VerticalAlignment="Center"
+                        ValueChanged="RgbSlider_OnValueChanged" />
+                <TextBlock Grid.Row="0" Grid.Column="2" HorizontalAlignment="Right" VerticalAlignment="Center"
+                           Text="{Binding ElementName=RedSlider, Path=Value, StringFormat={}{0:F0}}" />
+                <TextBlock Grid.Row="1" Grid.Column="0" Text="Green" Foreground="#FF81C784" VerticalAlignment="Center" />
+                <Slider Grid.Row="1" Grid.Column="1" Name="GreenSlider" Minimum="0" Maximum="255" VerticalAlignment="Center"
+                        ValueChanged="RgbSlider_OnValueChanged" />
+                <TextBlock Grid.Row="1" Grid.Column="2" HorizontalAlignment="Right" VerticalAlignment="Center"
+                           Text="{Binding ElementName=GreenSlider, Path=Value, StringFormat={}{0:F0}}" />
+                <TextBlock Grid.Row="2" Grid.Column="0" Text="Blue" Foreground="#FF64B5F6" VerticalAlignment="Center" />
+                <Slider Grid.Row="2" Grid.Column="1" Name="BlueSlider" Minimum="0" Maximum="255" VerticalAlignment="Center"
+                        ValueChanged="RgbSlider_OnValueChanged" />
+                <TextBlock Grid.Row="2" Grid.Column="2" HorizontalAlignment="Right" VerticalAlignment="Center"
+                           Text="{Binding ElementName=BlueSlider, Path=Value, StringFormat={}{0:F0}}" />
+            </Grid>
+            <DockPanel Name="AddColorPanel" Margin="0,16,0,0" Visibility="Collapsed" LastChildFill="False">
+                <TextBlock Text="Add a color to fix (R,G,B):" VerticalAlignment="Center" Margin="0,0,8,0" />
+                <TextBox Name="CustomColorBox" Width="110" VerticalAlignment="Center" />
+                <Button Content="Add" Width="60" Margin="8,0,0,0" Click="AddColor_OnClick" />
+            </DockPanel>
+        </StackPanel>
+
+        <!-- Buttons -->
+        <DockPanel Grid.Row="2" LastChildFill="False" Margin="0,12,0,0">
+            <Button DockPanel.Dock="Left" Name="CancelButton" Content="Cancel" Width="90" Height="28" Click="CancelButton_OnClick" />
+            <Button DockPanel.Dock="Right" Name="NextButton" Content="Start" Width="90" Height="28" Margin="6,0,0,0" Click="NextButton_OnClick" />
+            <Button DockPanel.Dock="Right" Name="BackButton" Content="Back" Width="90" Height="28" Visibility="Collapsed" Click="BackButton_OnClick" />
+        </DockPanel>
+    </Grid>
+</Window>

--- a/Project-Aurora/Project-Aurora/Controls/Control_CalibrationWizard.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Controls/Control_CalibrationWizard.xaml.cs
@@ -1,0 +1,379 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.ComponentModel;
+using System.Threading.Tasks;
+using System.Windows;
+using AuroraRgb.Devices;
+using Common;
+using Common.Devices;
+using Common.Devices.RGBNet;
+using Common.Utils;
+
+namespace AuroraRgb.Controls;
+
+public partial class Control_CalibrationWizard
+{
+    // Stage 1 (brightness) samples each channel at these mid levels; 0 and full are anchored.
+    private static readonly byte[] CurveLevels = [85, 170];
+
+    // Stage 2 (tonality) palette: white + primaries + secondaries, full intensity.
+    private static readonly SimpleColor[] Palette =
+    [
+        new(255, 255, 255), new(255, 0, 0), new(0, 255, 0), new(0, 0, 255),
+        new(255, 255, 0), new(0, 255, 255), new(255, 0, 255)
+    ];
+
+    private static readonly string[] PaletteNames = ["WHITE", "RED", "GREEN", "BLUE", "YELLOW", "CYAN", "MAGENTA"];
+
+    // Stage 3 (non-linear fixes): intermediate mixes a single matrix usually can't match.
+    private static readonly SimpleColor[] SuggestedSamples =
+    [
+        new(128, 0, 255), new(255, 0, 128),   // purples
+        new(0, 128, 255), new(0, 255, 128),   // teals
+        new(128, 255, 0), new(255, 128, 0),   // lime / orange
+        new(128, 128, 255), new(128, 255, 128), new(255, 128, 128), // pastels
+        new(128, 128, 128)                     // gray
+    ];
+
+    private static readonly string[] ChannelNames = ["RED", "GREEN", "BLUE"];
+
+    private readonly DeviceManager _deviceManager;
+    private readonly DeviceConfig _deviceConfig;
+    private readonly IReadOnlyList<RemappableDevice> _devices;
+
+    private readonly SingleConcurrentThread _worker;
+
+    private readonly byte[][] _curveOut =
+    [
+        (byte[])CurveLevels.Clone(), (byte[])CurveLevels.Clone(), (byte[])CurveLevels.Clone()
+    ];
+
+    private readonly SimpleColor[] _paletteOut = (SimpleColor[])Palette.Clone();
+
+    private readonly List<SimpleColor> _sampleSrc = [];
+    private readonly List<SimpleColor> _sampleOut = [];
+    private bool _phase3Seeded;
+    private DeviceCalibration _baseCalibration = DeviceCalibration.Identity;
+
+    private DeviceCalibration _existing = DeviceCalibration.Identity;
+
+    private readonly List<(int phase, int a, int b)> _steps = [];
+    private int _stepIndex = -1;
+    private bool _applyingStep;
+
+    private string _referenceId = "";
+    private string _targetId = "";
+    private SimpleColor _referenceColor;
+    private SimpleColor _targetColor;
+
+    public Control_CalibrationWizard(DeviceManager deviceManager, DeviceConfig deviceConfig, IReadOnlyList<RemappableDevice> devices)
+    {
+        _deviceManager = deviceManager;
+        _deviceConfig = deviceConfig;
+        _devices = devices;
+
+        _worker = new SingleConcurrentThread("Calibration Wizard", WorkerOnDoWork, ExceptionCallback);
+
+        InitializeComponent();
+
+        foreach (var device in _devices)
+        {
+            ReferenceCombo.Items.Add(device.DeviceSummary);
+            TargetCombo.Items.Add(device.DeviceSummary);
+        }
+
+        if (_devices.Count > 0) ReferenceCombo.SelectedIndex = 0;
+        if (_devices.Count > 1) TargetCombo.SelectedIndex = 1;
+    }
+
+    private static SimpleColor ChannelColor(int channel, byte value) => channel switch
+    {
+        0 => new SimpleColor(value, 0, 0),
+        1 => new SimpleColor(0, value, 0),
+        _ => new SimpleColor(0, 0, value)
+    };
+
+    private void NextButton_OnClick(object sender, RoutedEventArgs e)
+    {
+        if (_stepIndex < 0)
+        {
+            StartWizard();
+            return;
+        }
+
+        if (_stepIndex < _steps.Count - 1)
+        {
+            _stepIndex++;
+            ApplyStep();
+        }
+        else
+        {
+            Finish();
+        }
+    }
+
+    private void BackButton_OnClick(object sender, RoutedEventArgs e)
+    {
+        if (_stepIndex <= 0)
+        {
+            return;
+        }
+
+        _stepIndex--;
+        ApplyStep();
+    }
+
+    private void StartWizard()
+    {
+        var refIndex = ReferenceCombo.SelectedIndex;
+        var targetIndex = TargetCombo.SelectedIndex;
+        if (refIndex < 0 || targetIndex < 0 || refIndex == targetIndex)
+        {
+            SetupError.Text = "Pick two different devices.";
+            SetupError.Visibility = Visibility.Visible;
+            return;
+        }
+
+        _referenceId = _devices[refIndex].DeviceId;
+        _targetId = _devices[targetIndex].DeviceId;
+        _existing = _deviceConfig.DeviceColorCalibrations.GetValueOrDefault(_targetId, DeviceCalibration.Identity);
+
+        _sampleSrc.AddRange(SuggestedSamples);
+        _sampleOut.AddRange(SuggestedSamples);
+
+        _steps.Clear();
+        for (var channel = 0; channel < 3; channel++)
+        {
+            for (var levelIndex = 0; levelIndex < CurveLevels.Length; levelIndex++)
+            {
+                _steps.Add((1, channel, levelIndex));
+            }
+        }
+
+        for (var colorIndex = 0; colorIndex < Palette.Length; colorIndex++)
+        {
+            _steps.Add((2, colorIndex, 0));
+        }
+
+        for (var sampleIndex = 0; sampleIndex < _sampleSrc.Count; sampleIndex++)
+        {
+            _steps.Add((3, sampleIndex, 0));
+        }
+
+        SetupPanel.Visibility = Visibility.Collapsed;
+        BackButton.Visibility = Visibility.Visible;
+
+        _stepIndex = 0;
+        ApplyStep();
+    }
+
+    private void ApplyStep()
+    {
+        var (phase, a, b) = _steps[_stepIndex];
+        _applyingStep = true;
+
+        if (phase == 1)
+        {
+            var channel = a;
+            var input = CurveLevels[b];
+            var output = _curveOut[channel][b];
+            _referenceColor = ChannelColor(channel, input);
+            _targetColor = ChannelColor(channel, output);
+            OutputSlider.Value = output;
+
+            Phase1Step.Text = $"Step {_stepIndex + 1}/{_steps.Count} — {ChannelNames[channel]} brightness at {input * 100 / 255}%";
+            ShowPanel(1);
+        }
+        else
+        {
+            if (phase == 3 && !_phase3Seeded)
+            {
+                SeedPhase3();
+            }
+
+            SimpleColor reference, output;
+            string label;
+            if (phase == 2)
+            {
+                reference = Palette[a];
+                output = _paletteOut[a];
+                label = $"match {PaletteNames[a]}";
+            }
+            else
+            {
+                reference = _sampleSrc[a];
+                output = _sampleOut[a];
+                label = $"fine-tune {reference.R},{reference.G},{reference.B}";
+            }
+
+            _referenceColor = reference;
+            _targetColor = output;
+            RedSlider.Value = output.R;
+            GreenSlider.Value = output.G;
+            BlueSlider.Value = output.B;
+
+            Phase2Step.Text = $"Step {_stepIndex + 1}/{_steps.Count} — {label}";
+            AddColorPanel.Visibility = phase == 3 ? Visibility.Visible : Visibility.Collapsed;
+            ShowPanel(2);
+        }
+
+        NextButton.Content = _stepIndex == _steps.Count - 1 ? "Finish" : "Next";
+        BackButton.IsEnabled = _stepIndex > 0;
+        _applyingStep = false;
+
+        _worker.Trigger();
+    }
+
+    private void ShowPanel(int phase)
+    {
+        Phase1Panel.Visibility = phase == 1 ? Visibility.Visible : Visibility.Collapsed;
+        Phase2Panel.Visibility = phase == 2 ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    private void SeedPhase3()
+    {
+        _baseCalibration = _existing with
+        {
+            RedCurve = BuildCurve(0),
+            GreenCurve = BuildCurve(1),
+            BlueCurve = BuildCurve(2),
+            Matrix = CalibrationMath.FitColorMatrix(Palette, _paletteOut)
+        };
+
+        var lookup = _baseCalibration.GetLookup();
+        for (var i = 0; i < _sampleSrc.Count; i++)
+        {
+            _sampleOut[i] = lookup.Apply(_sampleSrc[i]);
+        }
+
+        _phase3Seeded = true;
+    }
+
+    private void OutputSlider_OnValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+    {
+        if (_applyingStep || _stepIndex < 0)
+        {
+            return;
+        }
+
+        var (phase, channel, levelIndex) = _steps[_stepIndex];
+        if (phase != 1)
+        {
+            return;
+        }
+
+        var output = (byte)e.NewValue;
+        _curveOut[channel][levelIndex] = output;
+        _targetColor = ChannelColor(channel, output);
+        _worker.Trigger();
+    }
+
+    private void RgbSlider_OnValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+    {
+        if (_applyingStep || _stepIndex < 0)
+        {
+            return;
+        }
+
+        var (phase, index, _) = _steps[_stepIndex];
+        _targetColor = new SimpleColor((byte)RedSlider.Value, (byte)GreenSlider.Value, (byte)BlueSlider.Value);
+
+        if (phase == 2)
+        {
+            _paletteOut[index] = _targetColor;
+        }
+        else if (phase == 3)
+        {
+            _sampleOut[index] = _targetColor;
+        }
+        else
+        {
+            return;
+        }
+
+        _worker.Trigger();
+    }
+
+    private void AddColor_OnClick(object sender, RoutedEventArgs e)
+    {
+        if (!TryParseColor(CustomColorBox.Text, out var color))
+        {
+            CustomColorBox.Text = "e.g. 127,0,255";
+            return;
+        }
+
+        _sampleSrc.Add(color);
+        _sampleOut.Add(_phase3Seeded ? _baseCalibration.GetLookup().Apply(color) : color);
+        _steps.Insert(_stepIndex + 1, (3, _sampleSrc.Count - 1, 0));
+
+        CustomColorBox.Clear();
+        _stepIndex++;
+        ApplyStep();
+    }
+
+    private static bool TryParseColor(string text, out SimpleColor color)
+    {
+        color = default;
+        var parts = text.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length != 3)
+        {
+            return false;
+        }
+
+        if (!byte.TryParse(parts[0], out var r) || !byte.TryParse(parts[1], out var g) || !byte.TryParse(parts[2], out var b))
+        {
+            return false;
+        }
+
+        color = new SimpleColor(r, g, b);
+        return true;
+    }
+
+    private async Task WorkerOnDoWork()
+    {
+        await _deviceManager.DevicesPipe.CalibrationPreview(_referenceId, _referenceColor);
+        await _deviceManager.DevicesPipe.CalibrationPreview(_targetId, _targetColor);
+    }
+
+    private async void Finish()
+    {
+        if (!_phase3Seeded)
+        {
+            SeedPhase3();
+        }
+
+        var samples = _sampleSrc.Select((src, i) => new ColorSample(src, _sampleOut[i])).ToArray();
+        var calibrated = _baseCalibration with { Samples = samples };
+
+        _deviceConfig.DeviceColorCalibrations[_targetId] = calibrated;
+        await _deviceManager.DevicesPipe.Recalibrate(_targetId, calibrated);
+        await _deviceManager.DevicesPipe.EndCalibration();
+        Close();
+    }
+
+    private CalibrationCurve BuildCurve(int channel)
+    {
+        // control points at the calibrated mid levels, with full intensity anchored to itself
+        // (the matrix handles full-intensity tonality/scaling).
+        byte[] inputs = [CurveLevels[0], CurveLevels[1], 255];
+        byte[] outputs = [_curveOut[channel][0], _curveOut[channel][1], 255];
+        return new CalibrationCurve(inputs, outputs);
+    }
+
+    private void CancelButton_OnClick(object sender, RoutedEventArgs e)
+    {
+        Close();
+    }
+
+    private void Window_OnClosing(object? sender, CancelEventArgs e)
+    {
+        // always restore normal rendering
+        _deviceManager.DevicesPipe.EndCalibration();
+    }
+
+    private static void ExceptionCallback(object? sender, SingleThreadExceptionEventArgs eventArgs)
+    {
+        Global.logger.Error(eventArgs.Exception, "Control_CalibrationWizard._worker");
+    }
+}

--- a/Project-Aurora/Project-Aurora/Controls/Control_DeviceCalibration.xaml
+++ b/Project-Aurora/Project-Aurora/Controls/Control_DeviceCalibration.xaml
@@ -10,7 +10,16 @@
         Loaded="Control_DeviceCalibration_OnLoaded"
         Title="Device Calibrations" Height="800" Width="800">
 
-    <ScrollViewer PanningMode="VerticalOnly">
-        <StackPanel Orientation="Vertical" Name="DeviceList" />
-    </ScrollViewer>
+    <DockPanel>
+        <DockPanel DockPanel.Dock="Top" Margin="8,8,8,4" LastChildFill="False">
+            <Button DockPanel.Dock="Right" Name="WizardButton" Content="Assisted Calibration…"
+                    Height="28" Padding="10,0" Click="WizardButton_OnClick"
+                    ToolTip="Guided wizard to match a device to a reference device across the whole color range" />
+            <TextBlock VerticalAlignment="Center" TextWrapping="Wrap"
+                       Text="Adjust sliders to fine-tune, or use Assisted Calibration to match devices step by step." />
+        </DockPanel>
+        <ScrollViewer PanningMode="VerticalOnly">
+            <StackPanel Orientation="Vertical" Name="DeviceList" />
+        </ScrollViewer>
+    </DockPanel>
 </fluentWpf:AcrylicWindow>

--- a/Project-Aurora/Project-Aurora/Controls/Control_DeviceCalibration.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Controls/Control_DeviceCalibration.xaml.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -21,6 +23,9 @@ public sealed partial class Control_DeviceCalibration : IDisposable
     private readonly TransparencyComponent _transparencyComponent;
     private readonly Task<IpcListener?> _ipcListener;
     private readonly SemaphoreSlim _devicesUpdated = new(0);
+
+    private Task<DeviceConfig>? _loadDeviceConfig;
+    private IReadOnlyList<RemappableDevice> _rgbNetDevices = [];
 
     public Control_DeviceCalibration(Task<DeviceManager> deviceManager, Task<IpcListener?> ipcListener)
     {
@@ -55,13 +60,15 @@ public sealed partial class Control_DeviceCalibration : IDisposable
         Dispatcher.BeginInvoke(() => DeviceList.Children.Clear(), DispatcherPriority.Loaded);
         var remappableDevices = ReadDevices(json);
         var loadDeviceConfig = ConfigManager.LoadDeviceConfig();
+        _loadDeviceConfig = loadDeviceConfig;
+        _rgbNetDevices = remappableDevices.Devices.Where(d => d.RgbNetLeds.Count > 0).ToList();
 
         foreach (var device in remappableDevices.Devices)
         {
-            var color = SimpleColor.FromArgb(device.Calibration.ToArgb());
+            var calibration = device.Calibration;
             Dispatcher.BeginInvoke(async () =>
             {
-                var calibrationItem = new Control_DeviceCalibrationItem(await _deviceManager, await loadDeviceConfig, device, color);
+                var calibrationItem = new Control_DeviceCalibrationItem(await _deviceManager, await loadDeviceConfig, device, calibration);
                 DeviceList.Children.Add(calibrationItem);
             }, DispatcherPriority.Loaded);
         }
@@ -108,6 +115,22 @@ public sealed partial class Control_DeviceCalibration : IDisposable
         }
 
         await RefreshLists();
+    }
+
+    private async void WizardButton_OnClick(object sender, RoutedEventArgs e)
+    {
+        if (_loadDeviceConfig is null || _rgbNetDevices.Count < 2)
+        {
+            MessageBox.Show("Assisted calibration needs at least two RGB.NET devices (a reference and a target).",
+                "Assisted Calibration", MessageBoxButton.OK, MessageBoxImage.Information);
+            return;
+        }
+
+        var wizard = new Control_CalibrationWizard(await _deviceManager, await _loadDeviceConfig, _rgbNetDevices)
+        {
+            Owner = GetWindow(this)
+        };
+        wizard.ShowDialog();
     }
 
     public void Dispose()

--- a/Project-Aurora/Project-Aurora/Controls/Control_DeviceCalibrationItem.xaml
+++ b/Project-Aurora/Project-Aurora/Controls/Control_DeviceCalibrationItem.xaml
@@ -1,35 +1,89 @@
-﻿<UserControl x:Class="AuroraRgb.Controls.Control_DeviceCalibrationItem"
+<UserControl x:Class="AuroraRgb.Controls.Control_DeviceCalibrationItem"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
              mc:Ignorable="d"
-             d:DesignHeight="50" d:DesignWidth="300">
-    
-    <Grid>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="5" />
-            <ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="Auto" />
-        </Grid.ColumnDefinitions>
-        <DockPanel Grid.Column="0">
-            <TextBlock Name="DeviceText" />
-        </DockPanel>
-        <StackPanel Orientation="Horizontal" Grid.Column="1">
-            <Separator Style="{StaticResource {x:Static ToolBar.SeparatorStyleKey}}" />
+             d:DesignHeight="220" d:DesignWidth="400">
+
+    <Border BorderBrush="#33888888" BorderThickness="1" CornerRadius="4" Margin="0,4" Padding="8">
+        <StackPanel Orientation="Vertical">
+            <DockPanel>
+                <Button DockPanel.Dock="Right" Width="60" Height="24" Click="ResetDevice_OnClick" Content="Reset" />
+                <TextBlock Name="DeviceText" FontWeight="Bold" VerticalAlignment="Center" TextWrapping="Wrap" />
+            </DockPanel>
+
+            <DockPanel Margin="0,4,0,0">
+                <Border DockPanel.Dock="Left" Name="StatusBadge" CornerRadius="3" Padding="6,1" VerticalAlignment="Center"
+                        Background="#33448AFF" BorderBrush="#88448AFF" BorderThickness="1">
+                    <TextBlock Name="StatusText" FontSize="11" />
+                </Border>
+            </DockPanel>
+
+            <!-- before/after preview: top = input, bottom = calibrated output -->
+            <Border Margin="0,6,0,0" BorderBrush="#33888888" BorderThickness="1" CornerRadius="2"
+                    ToolTip="Hue sweep — top half is the input color, bottom half is what's actually sent to the device after calibration.">
+                <Image Name="PreviewImage" Height="24" Stretch="Fill" RenderOptions.BitmapScalingMode="NearestNeighbor"
+                       SnapsToDevicePixels="True" />
+            </Border>
+
+            <Grid Margin="0,8,0,0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="70" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="50" />
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+
+                <TextBlock Grid.Row="0" Grid.Column="0" Text="Brightness" VerticalAlignment="Center" />
+                <Slider Grid.Row="0" Grid.Column="1" Name="BrightnessSlider" Minimum="0" Maximum="2" VerticalAlignment="Center"
+                        ValueChanged="Slider_OnValueChanged" />
+                <TextBlock Grid.Row="0" Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Right"
+                           Text="{Binding ElementName=BrightnessSlider, Path=Value, StringFormat={}{0:P0}}" />
+
+                <TextBlock Grid.Row="1" Grid.Column="0" Text="Gamma" VerticalAlignment="Center" />
+                <Slider Grid.Row="1" Grid.Column="1" Name="GammaSlider" Minimum="0.3" Maximum="3" VerticalAlignment="Center"
+                        ValueChanged="Slider_OnValueChanged" />
+                <TextBlock Grid.Row="1" Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Right"
+                           Text="{Binding ElementName=GammaSlider, Path=Value, StringFormat={}{0:F2}}" />
+
+                <TextBlock Grid.Row="2" Grid.Column="0" Text="Red" VerticalAlignment="Center" Foreground="#FFE57373" />
+                <Slider Grid.Row="2" Grid.Column="1" Name="RedSlider" Minimum="0" Maximum="2" VerticalAlignment="Center"
+                        ValueChanged="Slider_OnValueChanged" />
+                <TextBlock Grid.Row="2" Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Right"
+                           Text="{Binding ElementName=RedSlider, Path=Value, StringFormat={}{0:P0}}" />
+
+                <TextBlock Grid.Row="3" Grid.Column="0" Text="Green" VerticalAlignment="Center" Foreground="#FF81C784" />
+                <Slider Grid.Row="3" Grid.Column="1" Name="GreenSlider" Minimum="0" Maximum="2" VerticalAlignment="Center"
+                        ValueChanged="Slider_OnValueChanged" />
+                <TextBlock Grid.Row="3" Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Right"
+                           Text="{Binding ElementName=GreenSlider, Path=Value, StringFormat={}{0:P0}}" />
+
+                <TextBlock Grid.Row="4" Grid.Column="0" Text="Blue" VerticalAlignment="Center" Foreground="#FF64B5F6" />
+                <Slider Grid.Row="4" Grid.Column="1" Name="BlueSlider" Minimum="0" Maximum="2" VerticalAlignment="Center"
+                        ValueChanged="Slider_OnValueChanged" />
+                <TextBlock Grid.Row="4" Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Right"
+                           Text="{Binding ElementName=BlueSlider, Path=Value, StringFormat={}{0:P0}}" />
+            </Grid>
+
+            <Expander Name="DetailsExpander" Header="Details" Margin="0,6,0,0" FontSize="11" Visibility="Collapsed">
+                <StackPanel Margin="4,4,0,0">
+                    <StackPanel Name="MatrixSection" Visibility="Collapsed" Margin="0,0,0,6">
+                        <TextBlock Text="Color matrix (3×3):" Opacity="0.8" />
+                        <TextBlock Name="MatrixText" FontFamily="Consolas" />
+                    </StackPanel>
+                    <StackPanel Name="SamplesSection" Visibility="Collapsed">
+                        <TextBlock Name="SamplesHeader" Opacity="0.8" Text="3D-LUT correction points (input → output):" />
+                        <WrapPanel Name="SamplesPanel" Margin="0,2,0,0" />
+                    </StackPanel>
+                </StackPanel>
+            </Expander>
         </StackPanel>
-        <DockPanel Grid.Column="2">
-            <xctk:ColorPicker Name="ColorPicker"
-                SelectedColor="{Binding Path=Color, Mode=OneTime, Converter={StaticResource DrawingToMediaColorConv}}"
-                Width="123" Height="24"
-                ColorMode="ColorCanvas"
-                UsingAlphaChannel="False" 
-                SelectedColorChanged="ColorPicker_OnSelectedColorChanged"
-                
-            />
-        </DockPanel>
-        <Button Grid.Column="3" Width="30" Height="30" Click="ResetDevice_OnClick">x</Button>
-    </Grid>
+    </Border>
 </UserControl>

--- a/Project-Aurora/Project-Aurora/Controls/Control_DeviceCalibrationItem.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Controls/Control_DeviceCalibrationItem.xaml.cs
@@ -1,5 +1,12 @@
-﻿using System.Threading.Tasks;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
 using AuroraRgb.Devices;
 using Common;
 using Common.Devices;
@@ -11,41 +18,72 @@ namespace AuroraRgb.Controls;
 
 public partial class Control_DeviceCalibrationItem
 {
+    private const int PreviewWidth = 256;
+    private const int PreviewHeight = 24;
+
     private readonly SingleConcurrentThread _worker;
 
     private readonly DeviceManager _deviceManager;
     private readonly DeviceConfig _deviceConfig;
 
-    private SimpleColor _color;
+    private DeviceCalibration _calibration;
     private readonly string _deviceKey;
 
-    public Control_DeviceCalibrationItem(DeviceManager deviceManager, DeviceConfig deviceConfig, RemappableDevice device, SimpleColor color)
+    private bool _loaded;
+
+    public Control_DeviceCalibrationItem(DeviceManager deviceManager, DeviceConfig deviceConfig, RemappableDevice device, DeviceCalibration calibration)
     {
         _deviceManager = deviceManager;
         _deviceConfig = deviceConfig;
         _deviceKey = device.DeviceId;
-        _color = color;
+        _calibration = calibration;
 
         _worker = new SingleConcurrentThread("Device Calibration", WorkerOnDoWork, ExceptionCallback);
 
         InitializeComponent();
 
         DeviceText.Text = device.DeviceSummary;
-        ColorPicker.SelectedColor = MediaColor.FromArgb(_color.A, _color.R, _color.G, _color.B);
+        LoadCalibration(_calibration);
+        _loaded = true;
+
+        RefreshIndicators();
+        PopulateDetails();
     }
 
-    private void ColorPicker_OnSelectedColorChanged(object? sender, RoutedPropertyChangedEventArgs<MediaColor?> e)
+    private void LoadCalibration(DeviceCalibration calibration)
     {
-        var color = e.NewValue.GetValueOrDefault();
-        _color = new SimpleColor(color.R, color.G, color.B);
+        BrightnessSlider.Value = calibration.Brightness;
+        GammaSlider.Value = calibration.Gamma;
+        RedSlider.Value = calibration.RedGain;
+        GreenSlider.Value = calibration.GreenGain;
+        BlueSlider.Value = calibration.BlueGain;
+    }
 
-        _deviceConfig.DeviceCalibrations[_deviceKey] = _color;
+    private void Slider_OnValueChanged(object? sender, RoutedPropertyChangedEventArgs<double> e)
+    {
+        if (!_loaded)
+        {
+            return;
+        }
+
+        // preserve any wizard-built curves/matrix/samples; only the manual fine-tune changes here
+        _calibration = _calibration with
+        {
+            Brightness = BrightnessSlider.Value,
+            RedGain = RedSlider.Value,
+            GreenGain = GreenSlider.Value,
+            BlueGain = BlueSlider.Value,
+            Gamma = GammaSlider.Value
+        };
+
+        _deviceConfig.DeviceColorCalibrations[_deviceKey] = _calibration;
+        RefreshIndicators();
         _worker.Trigger();
     }
 
     private async Task WorkerOnDoWork()
     {
-        await _deviceManager.DevicesPipe.Recalibrate(_deviceKey, _color);
+        await _deviceManager.DevicesPipe.Recalibrate(_deviceKey, _calibration);
     }
 
     private static void ExceptionCallback(object? sender, SingleThreadExceptionEventArgs eventArgs)
@@ -55,6 +93,144 @@ public partial class Control_DeviceCalibrationItem
 
     private void ResetDevice_OnClick(object sender, RoutedEventArgs e)
     {
-        ColorPicker.SelectedColor = MediaColor.FromArgb(255, 255, 255, 255);
+        // full reset: clear curves, matrix and 3D-LUT, not just the manual sliders
+        _calibration = DeviceCalibration.Identity;
+        _loaded = false;
+        LoadCalibration(_calibration);
+        _loaded = true;
+
+        _deviceConfig.DeviceColorCalibrations[_deviceKey] = _calibration;
+        RefreshIndicators();
+        PopulateDetails();
+        _worker.Trigger();
     }
+
+    #region Indicators
+
+    private void RefreshIndicators()
+    {
+        StatusText.Text = Describe(_calibration);
+        RenderPreview();
+    }
+
+    private static string Describe(DeviceCalibration c)
+    {
+        var parts = new List<string>();
+        if (c.Samples is { Length: > 0 } s)
+        {
+            parts.Add($"3D-LUT · {s.Length} pts");
+        }
+
+        if (c.Matrix is { IsIdentity: false })
+        {
+            parts.Add("Matrix");
+        }
+
+        if (c.RedCurve is { IsIdentity: false } || c.GreenCurve is { IsIdentity: false } || c.BlueCurve is { IsIdentity: false })
+        {
+            parts.Add("Curves");
+        }
+
+        if (c.Brightness is not 1.0 || c.RedGain is not 1.0 || c.GreenGain is not 1.0 || c.BlueGain is not 1.0 || c.Gamma is not 1.0)
+        {
+            parts.Add("Manual");
+        }
+
+        return parts.Count > 0 ? string.Join("   ·   ", parts) : "No calibration";
+    }
+
+    private void RenderPreview()
+    {
+        var lookup = _calibration.GetLookup();
+        var bitmap = new WriteableBitmap(PreviewWidth, PreviewHeight, 96, 96, PixelFormats.Bgra32, null);
+        var stride = PreviewWidth * 4;
+        var pixels = new byte[PreviewHeight * stride];
+
+        for (var x = 0; x < PreviewWidth; x++)
+        {
+            var hue = x / (double)(PreviewWidth - 1) * 360.0;
+            var raw = HueColor(hue);
+            var calibrated = lookup.Apply(raw);
+            for (var y = 0; y < PreviewHeight; y++)
+            {
+                var c = y < PreviewHeight / 2 ? raw : calibrated;
+                var o = y * stride + x * 4;
+                pixels[o] = c.B;
+                pixels[o + 1] = c.G;
+                pixels[o + 2] = c.R;
+                pixels[o + 3] = 255;
+            }
+        }
+
+        bitmap.WritePixels(new Int32Rect(0, 0, PreviewWidth, PreviewHeight), pixels, stride, 0);
+        PreviewImage.Source = bitmap;
+    }
+
+    private void PopulateDetails()
+    {
+        var hasMatrix = _calibration.Matrix is { IsIdentity: false } m && m.Values.Length == 9;
+        MatrixSection.Visibility = hasMatrix ? Visibility.Visible : Visibility.Collapsed;
+        if (hasMatrix)
+        {
+            MatrixText.Text = FormatMatrix(_calibration.Matrix!.Values);
+        }
+
+        SamplesPanel.Children.Clear();
+        var hasSamples = _calibration.Samples is { Length: > 0 };
+        SamplesSection.Visibility = hasSamples ? Visibility.Visible : Visibility.Collapsed;
+        if (hasSamples)
+        {
+            foreach (var sample in _calibration.Samples!)
+            {
+                SamplesPanel.Children.Add(BuildSampleSwatch(sample));
+            }
+        }
+
+        DetailsExpander.Visibility = hasMatrix || hasSamples ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    private static string FormatMatrix(double[] v)
+    {
+        return string.Format(CultureInfo.InvariantCulture,
+            "{0,7:F3} {1,7:F3} {2,7:F3}\n{3,7:F3} {4,7:F3} {5,7:F3}\n{6,7:F3} {7,7:F3} {8,7:F3}",
+            v[0], v[1], v[2], v[3], v[4], v[5], v[6], v[7], v[8]);
+    }
+
+    private static UIElement BuildSampleSwatch(ColorSample sample)
+    {
+        var panel = new StackPanel { Orientation = Orientation.Horizontal, Margin = new Thickness(0, 0, 8, 4) };
+        panel.Children.Add(Swatch(sample.Source));
+        panel.Children.Add(new TextBlock { Text = "→", Margin = new Thickness(2, 0, 2, 0), VerticalAlignment = VerticalAlignment.Center, FontSize = 10 });
+        panel.Children.Add(Swatch(sample.Output));
+        panel.ToolTip = $"{sample.Source.R},{sample.Source.G},{sample.Source.B}  →  {sample.Output.R},{sample.Output.G},{sample.Output.B}";
+        return panel;
+    }
+
+    private static Rectangle Swatch(SimpleColor c) => new()
+    {
+        Width = 16,
+        Height = 16,
+        RadiusX = 2,
+        RadiusY = 2,
+        Stroke = new SolidColorBrush(MediaColor.FromArgb(0x66, 0x88, 0x88, 0x88)),
+        StrokeThickness = 1,
+        Fill = new SolidColorBrush(MediaColor.FromRgb(c.R, c.G, c.B))
+    };
+
+    private static SimpleColor HueColor(double hue)
+    {
+        var h = hue / 60.0;
+        var x = (byte)(255 * (1 - Math.Abs(h % 2 - 1)));
+        return ((int)h) switch
+        {
+            0 => new SimpleColor(255, x, 0),
+            1 => new SimpleColor(x, 255, 0),
+            2 => new SimpleColor(0, 255, x),
+            3 => new SimpleColor(0, x, 255),
+            4 => new SimpleColor(x, 0, 255),
+            _ => new SimpleColor(255, 0, x)
+        };
+    }
+
+    #endregion
 }

--- a/Project-Aurora/Project-Aurora/Devices/DevicesPipe.cs
+++ b/Project-Aurora/Project-Aurora/Devices/DevicesPipe.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.IO.Pipes;
 using System.Text;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Common;
 using Common.Devices;
@@ -84,10 +85,23 @@ public sealed class DevicesPipe
         await SendCommand(command);
     }
 
-    public async Task Recalibrate(string deviceName, SimpleColor color)
+    public async Task Recalibrate(string deviceName, DeviceCalibration calibration)
     {
-        var command = DeviceCommands.Recalibrate + Constants.StringSplit + deviceName + Constants.StringSplit + color.ToArgb();
+        // compact (single line) so the command survives the line-based pipe protocol
+        var json = JsonSerializer.Serialize(calibration);
+        var command = DeviceCommands.Recalibrate + Constants.StringSplit + deviceName + Constants.StringSplit + json;
         await SendCommand( command);
+    }
+
+    public async Task CalibrationPreview(string deviceName, SimpleColor color)
+    {
+        var command = DeviceCommands.CalibrationPreview + Constants.StringSplit + deviceName + Constants.StringSplit + color.ToArgb();
+        await SendCommand(command);
+    }
+
+    public async Task EndCalibration()
+    {
+        await SendCommand(DeviceCommands.CalibrationEnd);
     }
 
     async Task SendCommand(string command)

--- a/Project-Aurora/Project-Aurora/Devices/RGBNet/Config/DeviceMapping.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Devices/RGBNet/Config/DeviceMapping.xaml.cs
@@ -102,6 +102,12 @@ public partial class DeviceMapping
 
         foreach (var remappableDevicesDevice in remappableDevices.Devices)
         {
+            // calibration-only devices (e.g. non-RGB.NET) expose no remappable leds
+            if (remappableDevicesDevice.RgbNetLeds.Count == 0)
+            {
+                continue;
+            }
+
             _devices.Add(remappableDevicesDevice);
         }
 


### PR DESCRIPTION
# Per-device color calibration with assisted 3D-LUT wizard

Closes #293

## Summary

Makes RGB devices from different models look the same by extending per-device calibration into an optional color pipeline, plus an assisted wizard that matches a target device to a reference device by eye.

## Motivation

The same logical color renders slightly differently across devices. The existing `DeviceCalibrations` (one multiplicative `SimpleColor` per device) can only dim each channel — it can't fix non-linear brightness response, the tonality of mixed colors (white matches but purple doesn't), or specific stubborn colors.

## What's added

- **Calibration model** (`DeviceCalibration`): per-channel brightness `CalibrationCurve`, a 3×3 `ColorMatrix`, an optional non-linear set of `ColorSample`s baked into a 3D-LUT, plus the existing manual brightness/gamma/gain.
- **Runtime apply** (`CalibrationLookup`): `curve → matrix → 3D-LUT (trilinear) → manual`, resolved once per device update and cached. Applied for **all** device types — RGB.NET (per sub-device in `RgbNetDeviceUpdater`) and native (centrally in `DefaultDevice`).
- **Assisted wizard** (`Control_CalibrationWizard`): pick a reference + target device; stage 1 matches per-channel brightness, stage 2 fits the matrix from white + primaries + secondaries, stage 3 fixes specific intermediate colors (suggested list + add-your-own). Devices are lit to live test colors over the device-manager pipe (`calibrationPreview` / `calibrationEnd`).
- **Indicators** in the calibration window: a status badge (`3D-LUT · N pts · Matrix · Curves · Manual`), a before/after hue preview, and a Details panel showing the matrix and the LUT correction points.

## Backward compatibility

Legacy `DeviceCalibrations` (`SimpleColor`) are migrated into the new model on config load (`DeviceConfig.MigrateCalibrations`); the new data lives in `DeviceColorCalibrations`.

## Scope / limitations

- The assisted **preview** (lighting both devices) targets RGB.NET devices; native devices still get the runtime apply + manual sliders.
- The matrix is a linear approximation; the optional 3D-LUT covers the non-linear cases.
- No automated tests added — the repo has no test project; the color-matrix fit was validated by reasoning (identity in → identity out, scalar in → scalar matrix) and the runtime paths exercised live.

## How to test

1. Settings → Device Manager → **Calibrate Devices**.
2. Adjust the per-device sliders, or click **Assisted Calibration…** and follow the stages.
3. Verify the badge/preview/Details reflect the active calibration, and that devices visually match.

## Screenshots

<img width="805" height="805" alt="Captura de tela 2026-06-30 170531" src="https://github.com/user-attachments/assets/49091e28-9855-42a1-b8e8-aa811add06a4" />
<img width="543" height="462" alt="Captura de tela 2026-06-30 170539" src="https://github.com/user-attachments/assets/e70d166f-8773-44aa-9670-3c180872b76a" />
<img width="542" height="458" alt="Captura de tela 2026-06-30 170549" src="https://github.com/user-attachments/assets/4e912267-84a3-4fad-a2eb-18b9896306b4" />
<img width="544" height="470" alt="Captura de tela 2026-06-30 170556" src="https://github.com/user-attachments/assets/9a65f269-9142-4074-9dac-b5715f695627" />
<img width="545" height="466" alt="Captura de tela 2026-06-30 170603" src="https://github.com/user-attachments/assets/772f4c1b-67f4-40d6-8204-b07c6871099a" />
<img width="541" height="460" alt="Captura de tela 2026-06-30 170610" src="https://github.com/user-attachments/assets/7bb49003-9cac-4a7d-aa0c-487187aa7f5e" />

