### PR TITLE
fix(razer): smooth wrapper colours between Chroma service updates

### DIFF
--- a/Project-Aurora/Project-Aurora/Modules/Razer/RzHelper.cs
+++ b/Project-Aurora/Project-Aurora/Modules/Razer/RzHelper.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using AuroraRgb.Settings.Layers;
 using Microsoft.Win32;
 using RazerSdkReader;
 using RazerSdkReader.Structures;
@@ -34,7 +32,6 @@ public static class RzHelper
         }
     }
 
-    private static HashSet<int> _updatedLayers = new();
     private static string? _currentAppExecutable = string.Empty;
 
     /// <summary>
@@ -76,12 +73,6 @@ public static class RzHelper
     public static bool IsSdkVersionSupported(RzSdkVersion version)
         => version >= SupportedFromVersion && version < SupportedToVersion;
 
-    public static bool IsStale(RazerLayerHandler razerLayerHandler)
-    {
-        var hash = razerLayerHandler.GetHashCode();
-        return !_updatedLayers.Add(hash);
-    }
-
     public static bool IsCurrentAppValid() => !string.IsNullOrEmpty(CurrentAppExecutable) && CurrentAppExecutable != Global.AuroraExe;
 
     public static void Initialize(ChromaReader sdkManager)
@@ -90,35 +81,30 @@ public static class RzHelper
         {
             KeyboardColors.Provider = keyboard;
             KeyboardColors.IsDirty = true;
-            _updatedLayers.Clear();
         };
 
         sdkManager.MouseUpdated += (object? _, in ChromaMouse mouse) =>
         {
             MouseColors.Provider = mouse;
             MouseColors.IsDirty = true;
-            _updatedLayers.Clear();
         };
 
         sdkManager.MousepadUpdated += (object? _, in ChromaMousepad mousepad) =>
         {
             MousepadColors.Provider = mousepad;
             MousepadColors.IsDirty = true;
-            _updatedLayers.Clear();
         };
         
         sdkManager.HeadsetUpdated += (object? _, in ChromaHeadset headset) =>
         {
             HeadsetColors.Provider = headset;
             HeadsetColors.IsDirty = true;
-            _updatedLayers.Clear();
         };
 
         sdkManager.ChromaLinkUpdated += (object? _, in ChromaLink link) =>
         {
             ChromaLinkColors.Provider = link;
             ChromaLinkColors.IsDirty = true;
-            _updatedLayers.Clear();
         };
 
         sdkManager.AppDataUpdated += (object? _, in ChromaAppData appData) =>

--- a/Project-Aurora/Project-Aurora/Settings/Layers/RazerLayerHandler.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/RazerLayerHandler.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Drawing;
+using System.Numerics;
 using System.Windows.Controls;
 using AuroraRgb.EffectsEngine;
 using AuroraRgb.Modules.Razer;
@@ -59,6 +61,15 @@ public partial class RazerLayerHandlerProperties : LayerHandlerProperties
         set => _hueShift = value;
     }
 
+    private bool? _smoothingEnabled;
+    [JsonProperty("_SmoothingEnabled")]
+    [LogicOverridable("Enable Smoothing")]
+    public bool SmoothingEnabled
+    {
+        get => Logic?._smoothingEnabled ?? _smoothingEnabled ?? true;
+        set => _smoothingEnabled = value;
+    }
+
     private Dictionary<DeviceKeys, DeviceKeys> _keyCloneMap = new();
     [JsonProperty("_KeyCloneMap")]
     public Dictionary<DeviceKeys, DeviceKeys> KeyCloneMap
@@ -75,6 +86,7 @@ public partial class RazerLayerHandlerProperties : LayerHandlerProperties
         _brightnessChange = 0;
         _saturationChange = 0;
         _hueShift = 0;
+        _smoothingEnabled = true;
         _keyCloneMap = new Dictionary<DeviceKeys, DeviceKeys>();
     }
 }
@@ -91,29 +103,64 @@ public class RazerLayerHandler() : LayerHandler<RazerLayerHandlerProperties>("Ch
 
     private static readonly DeviceKeys[] DeviceKeysArray = Enum.GetValues<DeviceKeys>();
 
+    // The Chroma service writes the emulator buffers at ~10 Hz with occasional multi-frame
+    // gaps, so raw values step visibly. Each key eases toward the newest service colour per
+    // render tick, turning those steps into fades.
+    private const double SmoothingTau = 0.10;
+
+    private readonly Dictionary<DeviceKeys, Vector4> _smoothed = new();
+    private long _lastRenderTimestamp;
+
     public override EffectLayer Render(IGameState gameState)
     {
         if (!RzHelper.IsCurrentAppValid())
         {
+            _smoothed.Clear();
+            _lastRenderTimestamp = 0;
             return EmptyLayer.Instance;
         }
-        if (RzHelper.IsStale(this))
-            return EffectLayer;
+
+        var now = Stopwatch.GetTimestamp();
+        var dt = _lastRenderTimestamp == 0 ? SmoothingTau : (now - _lastRenderTimestamp) / (double)Stopwatch.Frequency;
+        _lastRenderTimestamp = now;
+        var alpha = Properties.SmoothingEnabled ? (float)(1 - Math.Exp(-dt / SmoothingTau)) : 1f;
 
         foreach (var key in DeviceKeysArray)
         {
             if (!TryGetColor(key, out var color))
                 continue;
-                
+
+            color = Smooth(key, color, alpha);
             EffectLayer.Set(key, in color);
         }
 
         foreach (var target in Properties.KeyCloneMap)
-            if(TryGetColor(target.Value, out var clr))
-                EffectLayer.Set(target.Key, in clr);
+        {
+            if (!_smoothed.TryGetValue(target.Value, out var source))
+                continue;
+            var color = ToColor(source);
+            EffectLayer.Set(target.Key, in color);
+        }
 
         return EffectLayer;
     }
+
+    private Color Smooth(DeviceKeys key, Color target, float alpha)
+    {
+        var targetVector = new Vector4(target.A, target.R, target.G, target.B);
+        if (alpha >= 1f || !_smoothed.TryGetValue(key, out var current))
+        {
+            _smoothed[key] = targetVector;
+            return target;
+        }
+
+        current += (targetVector - current) * alpha;
+        _smoothed[key] = current;
+        return ToColor(current);
+    }
+
+    private static Color ToColor(Vector4 argb) => Color.FromArgb(
+        (int)Math.Round(argb.X), (int)Math.Round(argb.Y), (int)Math.Round(argb.Z), (int)Math.Round(argb.W));
 
     private bool TryGetColor(DeviceKeys key, out Color color)
     {


### PR DESCRIPTION
**List any issues that this PR fixes:** none

**This pull request proposes the following changes:**
- The Razer Chroma wrapper layer now eases each key toward the newest service colour per render tick (exponential smoothing, time constant 100 ms; new per-layer `SmoothingEnabled` property, default on, logic-overridable)
- Removes the `RzHelper.IsStale`/`_updatedLayers` short-circuit: it was a plain `HashSet` cleared from the reader thread while the render thread `Add`ed, which corrupts the set (observed in the wild: `InvalidOperationException: Operations that change non-concurrent collections must have exclusive access` thrown from `RazerLayerHandler.Render`); smoothing needs per-tick rendering anyway

**Why:** measured on a live system (RazerSdkReader with no work in the hot path), `RzSDKService` republishes the emulator keyboard buffer at most ~10 Hz (inter-update intervals cluster at ~100 ms) with occasional 200-600 ms gaps followed by colour jumps. Mirrored raw, a classic Chroma game whose effect ramps colours (e.g. BG3's breathing menu) looks visibly stepped on the keyboard.

This ~10 Hz is not the reader being slow: Razer's own [Chroma SDK FAQ](https://developer.razer.com/works-with-chroma/chroma-faq/) states that "reducing the delay down below 100ms starts to really get out of sync and the keyboard seems to lose steady timing", while animation content is authored at 30 FPS (verified: the 007 catalog keyboard `.chroma` frames are a uniform 33 ms). So the pipeline delivers ~30 FPS content over a link that only reliably services ~10 Hz, and the documented pipeline has no interpolation step to bridge the two. This layer adds that step client-side: easing toward the latest buffer value each render tick reconstructs the intended motion instead of showing the raw ~10 Hz samples. It is opt-out via `SmoothingEnabled`.

**Known issues/To do:**
- none known


