### PR TITLE
Add direct-HID device for SteelSeries Apex Pro Gen 3 keyboards

### DIFF
--- a/Project-Aurora/AuroraDeviceManager/Devices/SteelSeries/ApexGen3Oled.cs
+++ b/Project-Aurora/AuroraDeviceManager/Devices/SteelSeries/ApexGen3Oled.cs
@@ -1,0 +1,442 @@
+using System.Runtime.InteropServices;
+using Common.Devices;
+using HidSharp;
+using Windows.Media.Control;
+
+namespace AuroraDeviceManager.Devices.SteelSeries;
+
+// gamesense-essentials parity for the Gen 3 OLED (128x40, 1bpp), driven from the device
+// update loop. Content priority: volume slider (briefly, after a volume change) >
+// song info while media plays (with a periodic clock window) > clock with day/date.
+// Frame format: unnumbered feature report [0x00, 0x61, <SSD1306 page-major bitmap>].
+internal sealed class ApexGen3Oled
+{
+    private const int Width = 128;
+    private const int Height = 40;
+    private const byte Command = 0x61;
+    private const int VolumeOverlayMs = 1500;
+    private const int MediaPollMs = 2000;
+    private const int PeriodicClockPeriodS = 30; // last 5s of every 30s window shows the clock
+
+    private bool _clock, _clockIcon, _clockPeriodic, _volume, _song, _songIcon, _songFlip;
+    private string _separator = " - ";
+    private int _tickMs = 250;
+
+    private byte[] _lastFrame = [];
+    private bool _sendErrorLogged;
+
+    private float _lastVol = -1;
+    private bool _lastMute;
+    private DateTime _volShownUntil = DateTime.MinValue;
+    private CoreAudioVolume? _coreAudio;
+    private bool _volBroken;
+
+    private DateTime _lastMediaPoll = DateTime.MinValue;
+    private GlobalSystemMediaTransportControlsSessionManager? _smtc;
+    private volatile string _title = "";
+    private volatile string _artist = "";
+    private volatile bool _playing;
+    private bool _mediaPollRunning;
+    private bool _mediaBroken;
+
+    public void RegisterVariables(VariableRegistry registry, string dev)
+    {
+        registry.Register($"{dev}_oled_clock", true, "OLED: clock (HH:mm with day and date)");
+        registry.Register($"{dev}_oled_clock_icon", true, "OLED: clock icon");
+        registry.Register($"{dev}_oled_clock_periodic", true, "OLED: show the clock periodically while music plays");
+        registry.Register($"{dev}_oled_volume", true, "OLED: volume slider on volume changes");
+        registry.Register($"{dev}_oled_song", true, "OLED: song information while music plays");
+        registry.Register($"{dev}_oled_song_icon", true, "OLED: song icon");
+        registry.Register($"{dev}_oled_song_flip", false, "OLED: artist above title");
+        registry.Register($"{dev}_oled_song_separator", " - ", "OLED: scrolling separator");
+        registry.Register($"{dev}_oled_tick_ms", 250, "OLED: scroll tick (ms)");
+    }
+
+    public void Initialize(string dev)
+    {
+        var vars = Global.DeviceConfig.VarRegistry;
+        _clock = vars.GetVariable<bool>($"{dev}_oled_clock");
+        _clockIcon = vars.GetVariable<bool>($"{dev}_oled_clock_icon");
+        _clockPeriodic = vars.GetVariable<bool>($"{dev}_oled_clock_periodic");
+        _volume = vars.GetVariable<bool>($"{dev}_oled_volume");
+        _song = vars.GetVariable<bool>($"{dev}_oled_song");
+        _songIcon = vars.GetVariable<bool>($"{dev}_oled_song_icon");
+        _songFlip = vars.GetVariable<bool>($"{dev}_oled_song_flip");
+        var separator = vars.GetString($"{dev}_oled_song_separator");
+        _separator = string.IsNullOrEmpty(separator) ? " - " : separator;
+        _tickMs = Math.Max(50, vars.GetVariable<int>($"{dev}_oled_tick_ms"));
+        _lastFrame = [];
+        _lastVol = -1;
+        _sendErrorLogged = false;
+    }
+
+    public void Tick(HidStream stream, int reportLength, Action<string, Exception> logError)
+    {
+        var now = DateTime.Now;
+        PollVolume(now);
+        PollMedia(now);
+
+        var frame = new byte[reportLength];
+        frame[1] = Command;
+
+        if (_volume && now < _volShownUntil)
+            DrawVolumeScreen(frame);
+        else if (_song && _playing && !(InPeriodicClockWindow(now) && _clock))
+            DrawSongScreen(frame, now);
+        else if (_clock)
+            DrawClockScreen(frame, now);
+
+        if (_lastFrame.AsSpan().SequenceEqual(frame))
+            return;
+
+        try
+        {
+            stream.SetFeature(frame);
+            _lastFrame = frame;
+            _sendErrorLogged = false;
+        }
+        catch (Exception e)
+        {
+            if (!_sendErrorLogged)
+            {
+                logError("failed to write OLED frame", e);
+                _sendErrorLogged = true;
+            }
+            _lastFrame = frame; // do not retry the same frame every tick
+        }
+    }
+
+    private bool InPeriodicClockWindow(DateTime now) =>
+        _clockPeriodic && now.Second % PeriodicClockPeriodS >= PeriodicClockPeriodS - 5;
+
+    private void PollVolume(DateTime now)
+    {
+        if (!_volume || _volBroken)
+            return;
+
+        try
+        {
+            _coreAudio ??= new CoreAudioVolume();
+            var (vol, mute) = _coreAudio.Get();
+            if (_lastVol >= 0 && (Math.Abs(vol - _lastVol) > 0.001f || mute != _lastMute))
+                _volShownUntil = now.AddMilliseconds(VolumeOverlayMs);
+            _lastVol = vol;
+            _lastMute = mute;
+        }
+        catch
+        {
+            // audio endpoint may be switching; retry from scratch, give up only on repeated failure
+            _coreAudio?.Dispose();
+            _coreAudio = null;
+            if (++_volFailures > 5)
+                _volBroken = true;
+        }
+    }
+
+    private int _volFailures;
+
+    private void PollMedia(DateTime now)
+    {
+        if (!_song || _mediaBroken || _mediaPollRunning || (now - _lastMediaPoll).TotalMilliseconds < MediaPollMs)
+            return;
+
+        _lastMediaPoll = now;
+        _mediaPollRunning = true;
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                _smtc ??= await GlobalSystemMediaTransportControlsSessionManager.RequestAsync();
+                var session = _smtc.GetCurrentSession();
+                if (session == null)
+                {
+                    _playing = false;
+                    return;
+                }
+
+                _playing = session.GetPlaybackInfo().PlaybackStatus ==
+                           GlobalSystemMediaTransportControlsSessionPlaybackStatus.Playing;
+                var props = await session.TryGetMediaPropertiesAsync();
+                _title = props.Title ?? "";
+                _artist = props.Artist ?? "";
+            }
+            catch
+            {
+                _mediaBroken = true; // WinRT SMTC unavailable; leave the clock in charge
+            }
+            finally
+            {
+                _mediaPollRunning = false;
+            }
+        });
+    }
+
+    private void DrawVolumeScreen(byte[] frame)
+    {
+        var pct = (int)Math.Round(_lastVol * 100);
+        var label = _lastMute ? "MUTE" : $"{pct}%";
+        DrawText(frame, (Width - label.Length * 6) / 2, 4, label);
+
+        // bar with 1px border, fill follows volume (empty when muted)
+        const int bx = 8, by = 20, bw = 112, bh = 12;
+        FillRect(frame, bx, by, bw, 1);
+        FillRect(frame, bx, by + bh - 1, bw, 1);
+        FillRect(frame, bx, by, 1, bh);
+        FillRect(frame, bx + bw - 1, by, 1, bh);
+        if (!_lastMute)
+            FillRect(frame, bx + 2, by + 2, (int)((bw - 4) * _lastVol), bh - 4);
+    }
+
+    private void DrawSongScreen(byte[] frame, DateTime now)
+    {
+        var line1 = _songFlip ? _artist : _title;
+        var line2 = _songFlip ? _title : _artist;
+
+        var x1 = 2;
+        if (_songIcon)
+        {
+            DrawIcon(frame, 2, 8, NoteIcon);
+            x1 = 14;
+        }
+
+        DrawScrollingText(frame, x1, 8, Width - x1 - 2, line1, now);
+        DrawScrollingText(frame, 2, 24, Width - 4, line2, now);
+    }
+
+    private void DrawScrollingText(byte[] frame, int x, int y, int avail, string text, DateTime now)
+    {
+        var maxChars = avail / 6;
+        if (text.Length <= maxChars)
+        {
+            DrawText(frame, x, y, text);
+            return;
+        }
+
+        var looped = text + _separator;
+        var offset = (int)(now.Ticks / TimeSpan.TicksPerMillisecond / _tickMs) % looped.Length;
+        Span<char> window = stackalloc char[maxChars];
+        for (var i = 0; i < maxChars; i++)
+            window[i] = looped[(offset + i) % looped.Length];
+        DrawText(frame, x, y, new string(window));
+    }
+
+    private void DrawClockScreen(byte[] frame, DateTime now)
+    {
+        if (_clockIcon)
+            DrawIcon(frame, 2, 2, ClockIcon);
+
+        const int dw = 15, dh = 26, t = 3, top = 1;
+
+        void DrawDigit(int x, int d)
+        {
+            var s = SevenSegment[d];
+            if ((s & 1) != 0) FillRect(frame, x, top, dw, t);
+            if ((s & 2) != 0) FillRect(frame, x + dw - t, top, t, dh / 2);
+            if ((s & 4) != 0) FillRect(frame, x + dw - t, top + dh / 2, t, dh / 2);
+            if ((s & 8) != 0) FillRect(frame, x, top + dh - t, dw, t);
+            if ((s & 16) != 0) FillRect(frame, x, top + dh / 2, t, dh / 2);
+            if ((s & 32) != 0) FillRect(frame, x, top, t, dh / 2);
+            if ((s & 64) != 0) FillRect(frame, x, top + dh / 2 - t / 2, dw, t);
+        }
+
+        var text = now.ToString("HHmm");
+        ReadOnlySpan<int> xs = [22, 43, 70, 91];
+        for (var i = 0; i < 4; i++)
+            DrawDigit(xs[i], text[i] - '0');
+        FillRect(frame, 62, top + 6, t, t);
+        FillRect(frame, 62, top + dh - 9, t, t);
+
+        var date = $"{now:ddd} {now:d}".ToUpperInvariant();
+        DrawText(frame, (Width - date.Length * 6) / 2, 32, date);
+    }
+
+    private static void FillRect(byte[] frame, int x, int y, int w, int h)
+    {
+        for (var yy = y; yy < y + h; yy++)
+        for (var xx = x; xx < x + w; xx++)
+        {
+            if ((uint)xx >= Width || (uint)yy >= Height) continue;
+            frame[2 + (yy >> 3) * Width + xx] |= (byte)(1 << (yy & 7));
+        }
+    }
+
+    private static void DrawText(byte[] frame, int x, int y, string text)
+    {
+        foreach (var raw in text)
+        {
+            var ch = SmallFont.ContainsKey(raw) ? raw : char.ToUpperInvariant(raw);
+            if (SmallFont.TryGetValue(ch, out var glyph))
+                for (var c = 0; c < 5; c++)
+                for (var b = 0; b < 7; b++)
+                    if ((glyph[c] & (1 << b)) != 0)
+                        FillRect(frame, x + c, y + b, 1, 1);
+            x += 6;
+            if (x >= Width) return;
+        }
+    }
+
+    private static void DrawIcon(byte[] frame, int x, int y, byte[] icon)
+    {
+        for (var c = 0; c < icon.Length; c++)
+        for (var b = 0; b < 8; b++)
+            if ((icon[c] & (1 << b)) != 0)
+                FillRect(frame, x + c, y + b, 1, 1);
+    }
+
+    // 8x8 icons, column bytes, bit 0 = top
+    private static readonly byte[] ClockIcon = [0x3C, 0x42, 0x81, 0x8F, 0x89, 0x81, 0x42, 0x3C];
+    private static readonly byte[] NoteIcon = [0x60, 0xF0, 0xF0, 0x7F, 0x01, 0x02, 0x0C, 0x00];
+
+    // segment bits: 1=top 2=right-top 4=right-bottom 8=bottom 16=left-bottom 32=left-top 64=middle
+    private static readonly byte[] SevenSegment = [0b0111111, 0b0000110, 0b1011011, 0b1001111, 0b1100110, 0b1101101, 0b1111101, 0b0000111, 0b1111111, 0b1101111];
+
+    // 5x7 column font (bit 0 = top)
+    private static readonly Dictionary<char, byte[]> SmallFont = new()
+    {
+        [' '] = [0x00, 0x00, 0x00, 0x00, 0x00],
+        ['0'] = [0x3E, 0x51, 0x49, 0x45, 0x3E],
+        ['1'] = [0x00, 0x42, 0x7F, 0x40, 0x00],
+        ['2'] = [0x42, 0x61, 0x51, 0x49, 0x46],
+        ['3'] = [0x21, 0x41, 0x45, 0x4B, 0x31],
+        ['4'] = [0x18, 0x14, 0x12, 0x7F, 0x10],
+        ['5'] = [0x27, 0x45, 0x45, 0x45, 0x39],
+        ['6'] = [0x3C, 0x4A, 0x49, 0x49, 0x30],
+        ['7'] = [0x01, 0x71, 0x09, 0x05, 0x03],
+        ['8'] = [0x36, 0x49, 0x49, 0x49, 0x36],
+        ['9'] = [0x06, 0x49, 0x49, 0x29, 0x1E],
+        ['A'] = [0x7E, 0x11, 0x11, 0x11, 0x7E],
+        ['B'] = [0x7F, 0x49, 0x49, 0x49, 0x36],
+        ['C'] = [0x3E, 0x41, 0x41, 0x41, 0x22],
+        ['D'] = [0x7F, 0x41, 0x41, 0x22, 0x1C],
+        ['E'] = [0x7F, 0x49, 0x49, 0x49, 0x41],
+        ['F'] = [0x7F, 0x09, 0x09, 0x09, 0x01],
+        ['G'] = [0x3E, 0x41, 0x49, 0x49, 0x7A],
+        ['H'] = [0x7F, 0x08, 0x08, 0x08, 0x7F],
+        ['I'] = [0x00, 0x41, 0x7F, 0x41, 0x00],
+        ['J'] = [0x20, 0x40, 0x41, 0x3F, 0x01],
+        ['K'] = [0x7F, 0x08, 0x14, 0x22, 0x41],
+        ['L'] = [0x7F, 0x40, 0x40, 0x40, 0x40],
+        ['M'] = [0x7F, 0x02, 0x0C, 0x02, 0x7F],
+        ['N'] = [0x7F, 0x04, 0x08, 0x10, 0x7F],
+        ['O'] = [0x3E, 0x41, 0x41, 0x41, 0x3E],
+        ['P'] = [0x7F, 0x09, 0x09, 0x09, 0x06],
+        ['Q'] = [0x3E, 0x41, 0x51, 0x21, 0x5E],
+        ['R'] = [0x7F, 0x09, 0x19, 0x29, 0x46],
+        ['S'] = [0x46, 0x49, 0x49, 0x49, 0x31],
+        ['T'] = [0x01, 0x01, 0x7F, 0x01, 0x01],
+        ['U'] = [0x3F, 0x40, 0x40, 0x40, 0x3F],
+        ['V'] = [0x1F, 0x20, 0x40, 0x20, 0x1F],
+        ['W'] = [0x3F, 0x40, 0x38, 0x40, 0x3F],
+        ['X'] = [0x63, 0x14, 0x08, 0x14, 0x63],
+        ['Y'] = [0x07, 0x08, 0x70, 0x08, 0x07],
+        ['Z'] = [0x61, 0x51, 0x49, 0x45, 0x43],
+        ['a'] = [0x20, 0x54, 0x54, 0x54, 0x78],
+        ['b'] = [0x7F, 0x48, 0x44, 0x44, 0x38],
+        ['c'] = [0x38, 0x44, 0x44, 0x44, 0x20],
+        ['d'] = [0x38, 0x44, 0x44, 0x48, 0x7F],
+        ['e'] = [0x38, 0x54, 0x54, 0x54, 0x18],
+        ['f'] = [0x08, 0x7E, 0x09, 0x01, 0x02],
+        ['g'] = [0x0C, 0x52, 0x52, 0x52, 0x3E],
+        ['h'] = [0x7F, 0x08, 0x04, 0x04, 0x78],
+        ['i'] = [0x00, 0x44, 0x7D, 0x40, 0x00],
+        ['j'] = [0x20, 0x40, 0x44, 0x3D, 0x00],
+        ['k'] = [0x7F, 0x10, 0x28, 0x44, 0x00],
+        ['l'] = [0x00, 0x41, 0x7F, 0x40, 0x00],
+        ['m'] = [0x7C, 0x04, 0x18, 0x04, 0x78],
+        ['n'] = [0x7C, 0x08, 0x04, 0x04, 0x78],
+        ['o'] = [0x38, 0x44, 0x44, 0x44, 0x38],
+        ['p'] = [0x7C, 0x14, 0x14, 0x14, 0x08],
+        ['q'] = [0x08, 0x14, 0x14, 0x18, 0x7C],
+        ['r'] = [0x7C, 0x08, 0x04, 0x04, 0x08],
+        ['s'] = [0x48, 0x54, 0x54, 0x54, 0x20],
+        ['t'] = [0x04, 0x3F, 0x44, 0x40, 0x20],
+        ['u'] = [0x3C, 0x40, 0x40, 0x20, 0x7C],
+        ['v'] = [0x1C, 0x20, 0x40, 0x20, 0x1C],
+        ['w'] = [0x3C, 0x40, 0x30, 0x40, 0x3C],
+        ['x'] = [0x44, 0x28, 0x10, 0x28, 0x44],
+        ['y'] = [0x0C, 0x50, 0x50, 0x50, 0x3C],
+        ['z'] = [0x44, 0x64, 0x54, 0x4C, 0x44],
+        ['-'] = [0x08, 0x08, 0x08, 0x08, 0x08],
+        ['/'] = [0x20, 0x10, 0x08, 0x04, 0x02],
+        ['.'] = [0x00, 0x60, 0x60, 0x00, 0x00],
+        [','] = [0x00, 0x50, 0x30, 0x00, 0x00],
+        ['\''] = [0x00, 0x05, 0x03, 0x00, 0x00],
+        ['"'] = [0x00, 0x07, 0x00, 0x07, 0x00],
+        ['!'] = [0x00, 0x00, 0x5F, 0x00, 0x00],
+        ['?'] = [0x02, 0x01, 0x51, 0x09, 0x06],
+        [':'] = [0x00, 0x36, 0x36, 0x00, 0x00],
+        [';'] = [0x00, 0x56, 0x36, 0x00, 0x00],
+        ['('] = [0x00, 0x1C, 0x22, 0x41, 0x00],
+        [')'] = [0x00, 0x41, 0x22, 0x1C, 0x00],
+        ['&'] = [0x36, 0x49, 0x55, 0x22, 0x50],
+        ['+'] = [0x08, 0x08, 0x3E, 0x08, 0x08],
+        ['='] = [0x14, 0x14, 0x14, 0x14, 0x14],
+        ['_'] = [0x40, 0x40, 0x40, 0x40, 0x40],
+        ['*'] = [0x14, 0x08, 0x3E, 0x08, 0x14],
+        ['%'] = [0x23, 0x13, 0x08, 0x64, 0x62],
+        ['#'] = [0x14, 0x7F, 0x14, 0x7F, 0x14],
+        ['@'] = [0x32, 0x49, 0x79, 0x41, 0x3E],
+        ['|'] = [0x00, 0x00, 0x7F, 0x00, 0x00],
+    };
+}
+
+// Minimal CoreAudio interop to read the default render endpoint's master volume.
+internal sealed class CoreAudioVolume : IDisposable
+{
+    private readonly IAudioEndpointVolume _volume;
+
+    public CoreAudioVolume()
+    {
+        var enumerator = (IMMDeviceEnumerator)new MMDeviceEnumerator();
+        Marshal.ThrowExceptionForHR(enumerator.GetDefaultAudioEndpoint(0 /* eRender */, 1 /* eMultimedia */, out var device));
+        var iid = typeof(IAudioEndpointVolume).GUID;
+        Marshal.ThrowExceptionForHR(device.Activate(ref iid, 1 /* CLSCTX_INPROC_SERVER */, IntPtr.Zero, out var itf));
+        _volume = (IAudioEndpointVolume)itf;
+    }
+
+    public (float Volume, bool Mute) Get()
+    {
+        Marshal.ThrowExceptionForHR(_volume.GetMasterVolumeLevelScalar(out var vol));
+        Marshal.ThrowExceptionForHR(_volume.GetMute(out var mute));
+        return (vol, mute);
+    }
+
+    public void Dispose()
+    {
+        // RCWs are released by the GC; nothing deterministic needed here.
+    }
+
+    [ComImport, Guid("BCDE0395-E52F-467C-8E3D-C4579291692E")]
+    private class MMDeviceEnumerator;
+
+    [ComImport, Guid("A95664D2-9614-4F35-A746-DE8DB63617E6"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    private interface IMMDeviceEnumerator
+    {
+        int EnumAudioEndpoints(int dataFlow, int stateMask, out IntPtr devices);
+        int GetDefaultAudioEndpoint(int dataFlow, int role, out IMMDevice endpoint);
+    }
+
+    [ComImport, Guid("D666063F-1587-4E43-81F1-B948E807363F"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    private interface IMMDevice
+    {
+        int Activate(ref Guid iid, int clsCtx, IntPtr activationParams, [MarshalAs(UnmanagedType.IUnknown)] out object itf);
+    }
+
+    [ComImport, Guid("5CDF2C82-841E-4546-9722-0CF74078229A"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    internal interface IAudioEndpointVolume
+    {
+        int RegisterControlChangeNotify(IntPtr notify);
+        int UnregisterControlChangeNotify(IntPtr notify);
+        int GetChannelCount(out uint count);
+        int SetMasterVolumeLevel(float level, ref Guid eventContext);
+        int SetMasterVolumeLevelScalar(float level, ref Guid eventContext);
+        int GetMasterVolumeLevel(out float level);
+        int GetMasterVolumeLevelScalar(out float level);
+        int SetChannelVolumeLevel(uint channel, float level, ref Guid eventContext);
+        int SetChannelVolumeLevelScalar(uint channel, float level, ref Guid eventContext);
+        int GetChannelVolumeLevel(uint channel, out float level);
+        int GetChannelVolumeLevelScalar(uint channel, out float level);
+        int SetMute(bool mute, ref Guid eventContext);
+        int GetMute(out bool mute);
+    }
+}

--- a/Project-Aurora/AuroraDeviceManager/Devices/SteelSeries/SteelSeriesApexGen3Device.cs
+++ b/Project-Aurora/AuroraDeviceManager/Devices/SteelSeries/SteelSeriesApexGen3Device.cs
@@ -17,9 +17,6 @@ public class SteelSeriesApexGen3Device : DefaultDevice
     private const int VendorId = 0x1038;
     private const int ReportLength = 642;
     private const byte SoftwareModeCommand = 0x4B;
-    private const byte OledCommand = 0x61;
-    private const int OledWidth = 128;
-    private const int OledHeight = 40;
 
     // Second report byte differs per model; the device ignores the frame when it is wrong.
     private static readonly (int Pid, byte ModelByte, string Model)[] SupportedDevices =
@@ -42,15 +39,14 @@ public class SteelSeriesApexGen3Device : DefaultDevice
     private readonly Stopwatch _statsWatch = Stopwatch.StartNew();
     private readonly Dictionary<byte, int> _hidSlot = new();
 
-    private bool _oledClock;
-    private int _lastClockMinute = -1;
+    private readonly ApexGen3Oled _oled = new();
 
     public override string DeviceName => "SteelSeries Apex Gen3";
 
     protected override void RegisterVariables(VariableRegistry variableRegistry)
     {
         base.RegisterVariables(variableRegistry);
-        variableRegistry.Register($"{DeviceName}_oled_clock", true, "Clock (HH:mm) on the OLED screen");
+        _oled.RegisterVariables(variableRegistry, DeviceName);
     }
 
     protected override string DeviceInfo => _deviceInfo;
@@ -85,8 +81,7 @@ public class SteelSeriesApexGen3Device : DefaultDevice
 
                 _deviceInfo = $"{model} (PID 0x{pid:X4})";
                 LogInfo($"connected to {_deviceInfo}, report length {reportLength}");
-                _oledClock = Global.DeviceConfig.VarRegistry.GetVariable<bool>($"{DeviceName}_oled_clock");
-                _lastClockMinute = -1;
+                _oled.Initialize(DeviceName);
                 IsInitialized = true;
                 return Task.FromResult(true);
             }
@@ -120,8 +115,7 @@ public class SteelSeriesApexGen3Device : DefaultDevice
         if (!IsInitialized || _stream == null)
             return Task.FromResult(false);
 
-        if (_oledClock)
-            UpdateOledClock();
+        _oled.Tick(_stream, _report.Length, LogError);
 
         _framesIn++;
         if (_statsWatch.ElapsedMilliseconds >= 10000)
@@ -206,126 +200,4 @@ public class SteelSeriesApexGen3Device : DefaultDevice
             return Task.FromResult(false);
         }
     }
-
-    // Replaces the GameSense-dependent gamesense-essentials clock. Protocol from apex-tux,
-    // probe-verified 2026-07-06: unnumbered feature report [0x00, 0x61, <bitmap>] padded to
-    // the max report length; bitmap is SSD1306 page-major (5 pages x 128 bytes, each byte
-    // 8 vertical pixels, bit 0 = topmost row of the page).
-    private void UpdateOledClock()
-    {
-        var now = DateTime.Now;
-        var minute = (int)(now.Ticks / TimeSpan.TicksPerMinute);
-        if (minute == _lastClockMinute)
-            return;
-
-        var report = new byte[_report.Length];
-        report[1] = OledCommand;
-        DrawClock(report, now);
-
-        try
-        {
-            _stream!.SetFeature(report);
-            _lastClockMinute = minute;
-        }
-        catch (Exception ex)
-        {
-            LogError("failed to write OLED clock", ex);
-            _lastClockMinute = minute; // do not retry every frame on a broken OLED path
-        }
-    }
-
-    // segment bits: 1=top 2=right-top 4=right-bottom 8=bottom 16=left-bottom 32=left-top 64=middle
-    private static readonly byte[] SevenSegment = [0b0111111, 0b0000110, 0b1011011, 0b1001111, 0b1100110, 0b1101101, 0b1111101, 0b0000111, 0b1111111, 0b1101111];
-
-    private static void DrawClock(byte[] report, DateTime now)
-    {
-        void FillRect(int x, int y, int w, int h)
-        {
-            for (var yy = y; yy < y + h; yy++)
-            for (var xx = x; xx < x + w; xx++)
-            {
-                if ((uint)xx >= OledWidth || (uint)yy >= OledHeight) continue;
-                report[2 + (yy >> 3) * OledWidth + xx] |= (byte)(1 << (yy & 7));
-            }
-        }
-
-        const int dw = 15, dh = 26, t = 3, top = 1;
-
-        void DrawDigit(int x, int d)
-        {
-            var s = SevenSegment[d];
-            if ((s & 1) != 0) FillRect(x, top, dw, t);
-            if ((s & 2) != 0) FillRect(x + dw - t, top, t, dh / 2);
-            if ((s & 4) != 0) FillRect(x + dw - t, top + dh / 2, t, dh / 2);
-            if ((s & 8) != 0) FillRect(x, top + dh - t, dw, t);
-            if ((s & 16) != 0) FillRect(x, top + dh / 2, t, dh / 2);
-            if ((s & 32) != 0) FillRect(x, top, t, dh / 2);
-            if ((s & 64) != 0) FillRect(x, top + dh / 2 - t / 2, dw, t);
-        }
-
-        var text = now.ToString("HHmm");
-        ReadOnlySpan<int> xs = [22, 43, 70, 91];
-        for (var i = 0; i < 4; i++)
-            DrawDigit(xs[i], text[i] - '0');
-        FillRect(62, top + 6, t, t);
-        FillRect(62, top + dh - 9, t, t);
-
-        // Abbreviated day name plus the Windows short-date format, centred under the time.
-        var date = $"{now:ddd} {now:d}".ToUpperInvariant();
-        var dateX = (OledWidth - date.Length * 6) / 2;
-        for (var i = 0; i < date.Length; i++)
-        {
-            if (!SmallFont.TryGetValue(date[i], out var glyph))
-                continue;
-            for (var c = 0; c < 5; c++)
-            for (var b = 0; b < 7; b++)
-                if ((glyph[c] & (1 << b)) != 0)
-                    FillRect(dateX + i * 6 + c, 32 + b, 1, 1);
-        }
-    }
-
-    // 5x7 column font (bit 0 = top) for short-date output: digits plus common separators.
-    private static readonly Dictionary<char, byte[]> SmallFont = new()
-    {
-        ['0'] = [0x3E, 0x51, 0x49, 0x45, 0x3E],
-        ['1'] = [0x00, 0x42, 0x7F, 0x40, 0x00],
-        ['2'] = [0x42, 0x61, 0x51, 0x49, 0x46],
-        ['3'] = [0x21, 0x41, 0x45, 0x4B, 0x31],
-        ['4'] = [0x18, 0x14, 0x12, 0x7F, 0x10],
-        ['5'] = [0x27, 0x45, 0x45, 0x45, 0x39],
-        ['6'] = [0x3C, 0x4A, 0x49, 0x49, 0x30],
-        ['7'] = [0x01, 0x71, 0x09, 0x05, 0x03],
-        ['8'] = [0x36, 0x49, 0x49, 0x49, 0x36],
-        ['9'] = [0x06, 0x49, 0x49, 0x29, 0x1E],
-        ['-'] = [0x08, 0x08, 0x08, 0x08, 0x08],
-        ['/'] = [0x20, 0x10, 0x08, 0x04, 0x02],
-        ['.'] = [0x00, 0x60, 0x60, 0x00, 0x00],
-        [' '] = [0x00, 0x00, 0x00, 0x00, 0x00],
-        ['A'] = [0x7E, 0x11, 0x11, 0x11, 0x7E],
-        ['B'] = [0x7F, 0x49, 0x49, 0x49, 0x36],
-        ['C'] = [0x3E, 0x41, 0x41, 0x41, 0x22],
-        ['D'] = [0x7F, 0x41, 0x41, 0x22, 0x1C],
-        ['E'] = [0x7F, 0x49, 0x49, 0x49, 0x41],
-        ['F'] = [0x7F, 0x09, 0x09, 0x09, 0x01],
-        ['G'] = [0x3E, 0x41, 0x49, 0x49, 0x7A],
-        ['H'] = [0x7F, 0x08, 0x08, 0x08, 0x7F],
-        ['I'] = [0x00, 0x41, 0x7F, 0x41, 0x00],
-        ['J'] = [0x20, 0x40, 0x41, 0x3F, 0x01],
-        ['K'] = [0x7F, 0x08, 0x14, 0x22, 0x41],
-        ['L'] = [0x7F, 0x40, 0x40, 0x40, 0x40],
-        ['M'] = [0x7F, 0x02, 0x0C, 0x02, 0x7F],
-        ['N'] = [0x7F, 0x04, 0x08, 0x10, 0x7F],
-        ['O'] = [0x3E, 0x41, 0x41, 0x41, 0x3E],
-        ['P'] = [0x7F, 0x09, 0x09, 0x09, 0x06],
-        ['Q'] = [0x3E, 0x41, 0x51, 0x21, 0x5E],
-        ['R'] = [0x7F, 0x09, 0x19, 0x29, 0x46],
-        ['S'] = [0x46, 0x49, 0x49, 0x49, 0x31],
-        ['T'] = [0x01, 0x01, 0x7F, 0x01, 0x01],
-        ['U'] = [0x3F, 0x40, 0x40, 0x40, 0x3F],
-        ['V'] = [0x1F, 0x20, 0x40, 0x20, 0x1F],
-        ['W'] = [0x3F, 0x40, 0x38, 0x40, 0x3F],
-        ['X'] = [0x63, 0x14, 0x08, 0x14, 0x63],
-        ['Y'] = [0x07, 0x08, 0x70, 0x08, 0x07],
-        ['Z'] = [0x61, 0x51, 0x49, 0x45, 0x43],
-    };
 }

--- a/Project-Aurora/AuroraDeviceManager/Devices/SteelSeries/SteelSeriesApexGen3Device.cs
+++ b/Project-Aurora/AuroraDeviceManager/Devices/SteelSeries/SteelSeriesApexGen3Device.cs
@@ -1,0 +1,331 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using Common;
+using Common.Devices;
+using Common.Utils;
+using HidSharp;
+
+namespace AuroraDeviceManager.Devices.SteelSeries;
+
+// Direct HID driver for the Apex Pro Gen 3 family: no GameSense/GG needed, Aurora owns the board.
+// Protocol (validated against SignalRGB 2.5.72 driving PID 0x1640 on 2026-07-05):
+//   vendor interface (mi_01, max feature report 643) takes FEATURE reports with report id 0x00;
+//   [0x00, 0x4B] enters software mode, [0x00, <modelByte>, <ledCount>, (<hidCode>, R, G, B)*] sets colours.
+// LED ids are USB HID keyboard usage codes, the same table GameSense used (USBHIDCodes.cs).
+public class SteelSeriesApexGen3Device : DefaultDevice
+{
+    private const int VendorId = 0x1038;
+    private const int ReportLength = 642;
+    private const byte SoftwareModeCommand = 0x4B;
+    private const byte OledCommand = 0x61;
+    private const int OledWidth = 128;
+    private const int OledHeight = 40;
+
+    // Second report byte differs per model; the device ignores the frame when it is wrong.
+    private static readonly (int Pid, byte ModelByte, string Model)[] SupportedDevices =
+    [
+        (0x1640, 0x3A, "Apex Pro Gen 3"),
+        (0x1642, 0x40, "Apex Pro TKL Gen 3"),
+        (0x1644, 0x61, "Apex Pro TKL Gen 3 Wireless"),
+        (0x1646, 0x21, "Apex Pro TKL Gen 3 Wireless (wired)"),
+        (0x1648, 0x40, "Apex Pro Mini Gen 3"),
+    ];
+
+    private HidStream? _stream;
+    private byte _modelByte;
+    private byte[] _report = new byte[ReportLength];
+    private byte[] _prevReport = new byte[ReportLength];
+
+    private long _framesIn;
+    private long _framesSkipped;
+    private long _framesWritten;
+    private readonly Stopwatch _statsWatch = Stopwatch.StartNew();
+    private readonly Dictionary<byte, int> _hidSlot = new();
+
+    private bool _oledClock;
+    private int _lastClockMinute = -1;
+
+    public override string DeviceName => "SteelSeries Apex Gen3";
+
+    protected override void RegisterVariables(VariableRegistry variableRegistry)
+    {
+        base.RegisterVariables(variableRegistry);
+        variableRegistry.Register($"{DeviceName}_oled_clock", true, "Clock (HH:mm) on the OLED screen");
+    }
+
+    protected override string DeviceInfo => _deviceInfo;
+    private string _deviceInfo = "";
+
+    protected override Task<bool> DoInitialize(CancellationToken cancellationToken)
+    {
+        foreach (var (pid, modelByte, model) in SupportedDevices)
+        {
+            // The vendor interface is the only one with feature reports large enough for a full colour frame.
+            var hidDevice = DeviceList.Local.GetHidDevices(VendorId, pid)
+                .FirstOrDefault(d => d.GetMaxFeatureReportLength() >= ReportLength);
+            if (hidDevice == null)
+                continue;
+
+            try
+            {
+                if (!hidDevice.TryOpen(out _stream))
+                {
+                    LogError($"{model} found but the HID interface could not be opened (in use by GG/SignalRGB?)");
+                    continue;
+                }
+
+                var reportLength = hidDevice.GetMaxFeatureReportLength();
+                _report = new byte[reportLength];
+                _prevReport = new byte[reportLength];
+                _modelByte = modelByte;
+
+                var softwareMode = new byte[reportLength];
+                softwareMode[1] = SoftwareModeCommand;
+                _stream.SetFeature(softwareMode);
+
+                _deviceInfo = $"{model} (PID 0x{pid:X4})";
+                LogInfo($"connected to {_deviceInfo}, report length {reportLength}");
+                _oledClock = Global.DeviceConfig.VarRegistry.GetVariable<bool>($"{DeviceName}_oled_clock");
+                _lastClockMinute = -1;
+                IsInitialized = true;
+                return Task.FromResult(true);
+            }
+            catch (Exception e)
+            {
+                LogError($"failed to initialize {model}", e);
+                _stream?.Dispose();
+                _stream = null;
+            }
+        }
+
+        return Task.FromResult(false);
+    }
+
+    protected override Task Shutdown()
+    {
+        try
+        {
+            _stream?.Dispose();
+        }
+        catch { /* device may already be gone */ }
+
+        _stream = null;
+        _deviceInfo = "";
+        IsInitialized = false;
+        return Task.CompletedTask;
+    }
+
+    protected override Task<bool> UpdateDevice(Dictionary<DeviceKeys, SimpleColor> keyColors, DoWorkEventArgs e, bool forced = false)
+    {
+        if (!IsInitialized || _stream == null)
+            return Task.FromResult(false);
+
+        if (_oledClock)
+            UpdateOledClock();
+
+        _framesIn++;
+        if (_statsWatch.ElapsedMilliseconds >= 10000)
+        {
+            LogInfo($"frames in={_framesIn} skipped={_framesSkipped} written={_framesWritten} (10s window)");
+            _framesIn = _framesSkipped = _framesWritten = 0;
+            _statsWatch.Restart();
+        }
+
+        Array.Clear(_report, 0, _report.Length);
+        _hidSlot.Clear();
+        _report[1] = _modelByte;
+
+        var ledCount = 0;
+        var maxLeds = (_report.Length - 3) / 4;
+        foreach (var (key, color) in keyColors)
+        {
+            // The board follows the standard USB HID usage table (probe-verified: 0xE5=RShift,
+            // 0xE7=RWin); only the apex/context key is vendor-specific at 0xF0.
+            var hid = key == DeviceKeys.APPLICATION_SELECT ? (byte)0xF0 : SteelSeriesDevice.GetHIDCode(key);
+            // 0x00 (legacy LOGO) floods the whole board; 0xE8-0xEF are GameSense G-key/logo
+            // aliases that do not exist as LEDs on Gen 3 hardware.
+            if (hid == 0x00 || hid == (byte)USBHIDCodes.ERROR || hid is >= 0xE8 and <= 0xEF)
+                continue;
+
+            var corrected = CommonColorUtils.CorrectWithAlpha(color);
+            // Several DeviceKeys alias to one hid code (TILDE/OEM variants, slash variants);
+            // unrendered aliases are black and must not overwrite a lit key.
+            if (_hidSlot.TryGetValue(hid, out var slot))
+            {
+                if (corrected is { R: 0, G: 0, B: 0 })
+                    continue;
+                _report[slot + 1] = corrected.R;
+                _report[slot + 2] = corrected.G;
+                _report[slot + 3] = corrected.B;
+                continue;
+            }
+
+            if (ledCount >= maxLeds)
+                continue;
+
+            var offset = 3 + ledCount * 4;
+            _hidSlot[hid] = offset;
+            _report[offset] = hid;
+            _report[offset + 1] = corrected.R;
+            _report[offset + 2] = corrected.G;
+            _report[offset + 3] = corrected.B;
+            ledCount++;
+        }
+
+        // The media/mute button next to the roller (led 251, "LCD Button") has no Aurora
+        // DeviceKeys the layouts render; it sits directly above Num -, so follow that key.
+        if (ledCount < maxLeds && keyColors.TryGetValue(DeviceKeys.NUM_MINUS, out var mediaColor))
+        {
+            var corrected = CommonColorUtils.CorrectWithAlpha(mediaColor);
+            var offset = 3 + ledCount * 4;
+            _report[offset] = 251;
+            _report[offset + 1] = corrected.R;
+            _report[offset + 2] = corrected.G;
+            _report[offset + 3] = corrected.B;
+            ledCount++;
+        }
+
+        _report[2] = (byte)ledCount;
+
+        if (!forced && _report.AsSpan().SequenceEqual(_prevReport))
+        {
+            _framesSkipped++;
+            return Task.FromResult(true);
+        }
+
+        try
+        {
+            _stream!.SetFeature(_report);
+            _framesWritten++;
+            (_prevReport, _report) = (_report, _prevReport);
+            return Task.FromResult(true);
+        }
+        catch (Exception ex)
+        {
+            LogError("failed to write colour report", ex);
+            return Task.FromResult(false);
+        }
+    }
+
+    // Replaces the GameSense-dependent gamesense-essentials clock. Protocol from apex-tux,
+    // probe-verified 2026-07-06: unnumbered feature report [0x00, 0x61, <bitmap>] padded to
+    // the max report length; bitmap is SSD1306 page-major (5 pages x 128 bytes, each byte
+    // 8 vertical pixels, bit 0 = topmost row of the page).
+    private void UpdateOledClock()
+    {
+        var now = DateTime.Now;
+        var minute = (int)(now.Ticks / TimeSpan.TicksPerMinute);
+        if (minute == _lastClockMinute)
+            return;
+
+        var report = new byte[_report.Length];
+        report[1] = OledCommand;
+        DrawClock(report, now);
+
+        try
+        {
+            _stream!.SetFeature(report);
+            _lastClockMinute = minute;
+        }
+        catch (Exception ex)
+        {
+            LogError("failed to write OLED clock", ex);
+            _lastClockMinute = minute; // do not retry every frame on a broken OLED path
+        }
+    }
+
+    // segment bits: 1=top 2=right-top 4=right-bottom 8=bottom 16=left-bottom 32=left-top 64=middle
+    private static readonly byte[] SevenSegment = [0b0111111, 0b0000110, 0b1011011, 0b1001111, 0b1100110, 0b1101101, 0b1111101, 0b0000111, 0b1111111, 0b1101111];
+
+    private static void DrawClock(byte[] report, DateTime now)
+    {
+        void FillRect(int x, int y, int w, int h)
+        {
+            for (var yy = y; yy < y + h; yy++)
+            for (var xx = x; xx < x + w; xx++)
+            {
+                if ((uint)xx >= OledWidth || (uint)yy >= OledHeight) continue;
+                report[2 + (yy >> 3) * OledWidth + xx] |= (byte)(1 << (yy & 7));
+            }
+        }
+
+        const int dw = 15, dh = 26, t = 3, top = 1;
+
+        void DrawDigit(int x, int d)
+        {
+            var s = SevenSegment[d];
+            if ((s & 1) != 0) FillRect(x, top, dw, t);
+            if ((s & 2) != 0) FillRect(x + dw - t, top, t, dh / 2);
+            if ((s & 4) != 0) FillRect(x + dw - t, top + dh / 2, t, dh / 2);
+            if ((s & 8) != 0) FillRect(x, top + dh - t, dw, t);
+            if ((s & 16) != 0) FillRect(x, top + dh / 2, t, dh / 2);
+            if ((s & 32) != 0) FillRect(x, top, t, dh / 2);
+            if ((s & 64) != 0) FillRect(x, top + dh / 2 - t / 2, dw, t);
+        }
+
+        var text = now.ToString("HHmm");
+        ReadOnlySpan<int> xs = [22, 43, 70, 91];
+        for (var i = 0; i < 4; i++)
+            DrawDigit(xs[i], text[i] - '0');
+        FillRect(62, top + 6, t, t);
+        FillRect(62, top + dh - 9, t, t);
+
+        // Abbreviated day name plus the Windows short-date format, centred under the time.
+        var date = $"{now:ddd} {now:d}".ToUpperInvariant();
+        var dateX = (OledWidth - date.Length * 6) / 2;
+        for (var i = 0; i < date.Length; i++)
+        {
+            if (!SmallFont.TryGetValue(date[i], out var glyph))
+                continue;
+            for (var c = 0; c < 5; c++)
+            for (var b = 0; b < 7; b++)
+                if ((glyph[c] & (1 << b)) != 0)
+                    FillRect(dateX + i * 6 + c, 32 + b, 1, 1);
+        }
+    }
+
+    // 5x7 column font (bit 0 = top) for short-date output: digits plus common separators.
+    private static readonly Dictionary<char, byte[]> SmallFont = new()
+    {
+        ['0'] = [0x3E, 0x51, 0x49, 0x45, 0x3E],
+        ['1'] = [0x00, 0x42, 0x7F, 0x40, 0x00],
+        ['2'] = [0x42, 0x61, 0x51, 0x49, 0x46],
+        ['3'] = [0x21, 0x41, 0x45, 0x4B, 0x31],
+        ['4'] = [0x18, 0x14, 0x12, 0x7F, 0x10],
+        ['5'] = [0x27, 0x45, 0x45, 0x45, 0x39],
+        ['6'] = [0x3C, 0x4A, 0x49, 0x49, 0x30],
+        ['7'] = [0x01, 0x71, 0x09, 0x05, 0x03],
+        ['8'] = [0x36, 0x49, 0x49, 0x49, 0x36],
+        ['9'] = [0x06, 0x49, 0x49, 0x29, 0x1E],
+        ['-'] = [0x08, 0x08, 0x08, 0x08, 0x08],
+        ['/'] = [0x20, 0x10, 0x08, 0x04, 0x02],
+        ['.'] = [0x00, 0x60, 0x60, 0x00, 0x00],
+        [' '] = [0x00, 0x00, 0x00, 0x00, 0x00],
+        ['A'] = [0x7E, 0x11, 0x11, 0x11, 0x7E],
+        ['B'] = [0x7F, 0x49, 0x49, 0x49, 0x36],
+        ['C'] = [0x3E, 0x41, 0x41, 0x41, 0x22],
+        ['D'] = [0x7F, 0x41, 0x41, 0x22, 0x1C],
+        ['E'] = [0x7F, 0x49, 0x49, 0x49, 0x41],
+        ['F'] = [0x7F, 0x09, 0x09, 0x09, 0x01],
+        ['G'] = [0x3E, 0x41, 0x49, 0x49, 0x7A],
+        ['H'] = [0x7F, 0x08, 0x08, 0x08, 0x7F],
+        ['I'] = [0x00, 0x41, 0x7F, 0x41, 0x00],
+        ['J'] = [0x20, 0x40, 0x41, 0x3F, 0x01],
+        ['K'] = [0x7F, 0x08, 0x14, 0x22, 0x41],
+        ['L'] = [0x7F, 0x40, 0x40, 0x40, 0x40],
+        ['M'] = [0x7F, 0x02, 0x0C, 0x02, 0x7F],
+        ['N'] = [0x7F, 0x04, 0x08, 0x10, 0x7F],
+        ['O'] = [0x3E, 0x41, 0x41, 0x41, 0x3E],
+        ['P'] = [0x7F, 0x09, 0x09, 0x09, 0x06],
+        ['Q'] = [0x3E, 0x41, 0x51, 0x21, 0x5E],
+        ['R'] = [0x7F, 0x09, 0x19, 0x29, 0x46],
+        ['S'] = [0x46, 0x49, 0x49, 0x49, 0x31],
+        ['T'] = [0x01, 0x01, 0x7F, 0x01, 0x01],
+        ['U'] = [0x3F, 0x40, 0x40, 0x40, 0x3F],
+        ['V'] = [0x1F, 0x20, 0x40, 0x20, 0x1F],
+        ['W'] = [0x3F, 0x40, 0x38, 0x40, 0x3F],
+        ['X'] = [0x63, 0x14, 0x08, 0x14, 0x63],
+        ['Y'] = [0x07, 0x08, 0x70, 0x08, 0x07],
+        ['Z'] = [0x61, 0x51, 0x49, 0x45, 0x43],
+    };
+}


### PR DESCRIPTION
**List any issues that this PR fixes:** none. #216 is related (Apex Pro support including the onboard display) but concerns the original Apex Pro (PID 0x1610), which this PR does not cover.

**This pull request proposes the following changes:**

Adds a native device for the SteelSeries Apex Pro Gen 3 family (PIDs 0x1640, 0x1642, 0x1644, 0x1646, 0x1648) that drives the keyboard over its vendor HID interface (usage page 0xFFC0), without SteelSeries GG/GameSense. This removes the GameSense rate limitations for these boards (SteelSeries/gamesense-sdk#34) and lets Aurora run them at full update rate, like the other direct-driven brands.

Relation to Aurora's existing SteelSeries support: both current paths - the "SteelSeries (RGB.NET)" device and the legacy GameSense device - talk to the keyboard through SteelSeries GG/Engine and require it to be running. For Gen 3 keyboards this device replaces that route entirely; the GameSense-based devices remain relevant for other SteelSeries hardware. Only one path should own a board: enabling this device together with a GameSense device (or running GG/SignalRGB alongside it) puts two writers on the same keyboard and causes flicker.

Protocol (observed from SignalRGB's device plugin and verified on a physical Apex Pro Gen 3, PID 0x1640):

- Colour frame: one unnumbered feature report `[0x00, <modelByte>, <ledCount>, (<hidUsage>, R, G, B)*]`, padded to the interface's max feature length (643). `modelByte` differs per PID and the board ignores frames with the wrong value.
- Led ids are standard USB HID keyboard usage codes; the context/menu key is vendor-specific 0xF0. Led id 0x00 acts as a whole-board broadcast and the legacy GameSense G-key/logo aliases (0xE8-0xEF) have no LEDs on Gen 3, so both are filtered. The existing `SteelSeriesDevice.GetHIDCode` table is reused.
- Software mode is entered once with `[0x00, 0x4B]`.
- OLED (128x40): feature report `[0x00, 0x61, <SSD1306 page-major bitmap>]` (format from apex-tux, github.com/not-jan/apex-tux). The device renders a clock with abbreviated day and the Windows short-date format, a volume slider that appears briefly on volume/mute changes (CoreAudio), and song title/artist while media plays (Windows SMTC), with scrolling for long texts and a periodic clock window during playback. This covers what gamesense-essentials (github.com/mtricht/gamesense-essentials) puts on the OLED; that tool talks to the GameSense HTTP API and stops working once GG is removed. Each element has a device variable (enable flags, artist/title flip, scroll separator, tick interval); frames are deduplicated so the screen only gets traffic when content changes.

Implementation notes:

- Multiple DeviceKeys alias to the same HID code (tilde/slash variants); an alias that renders black no longer overwrites a lit key in the same frame.
- Identical frames are deduplicated, so a static profile causes no USB traffic.
- The media/mute button next to the volume roller (led 251) has no corresponding DeviceKeys in the layouts; it follows Num - as its nearest neighbour.
- Only PID 0x1640 is hardware-verified; the other PIDs and their model bytes come from SignalRGB's device tables and apex-tux and are untested.